### PR TITLE
add global optional parameter create_lan_dhcp_server (default = true)

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -222,19 +222,20 @@ Each parameter can be configured simply as follows:
 The following table lists all the supported parameters, as well as their default values (applied when
 they are not configured explicitly):
 
-| Parameter           |    Values    | Description                                                                                   |      Default      |
-|:--------------------|:------------:|:----------------------------------------------------------------------------------------------|:-----------------:|
-| create_hub2hub_zone | true / false | Create System Zone for inter-regional Hub-to-Hub tunnels                                      |       true        |
-| hub2hub_zone        |   \<str\>    | Name of System Zone for inter-regional Hub-to-Hub tunnels _(when create_hub2hub_zone = true)_ | 'hub2hub_overlay' |
-| create_lan_zone     | true / false | Create System Zone for LAN interfaces (with 'role' = 'lan' in the profile)                    |       true        |
-| lan_zone            |   \<str\>    | Name of System Zone for LAN interfaces _(when create_lan_zone = true)_                        |    'lan_zone'     |
-| cert_auth           | true / false | Certificate-based auth for IKE/IPSEC                                                          |       true        |
-| hub_cert_template   |   \<str\>    | Certificate name on Hubs _(when cert_auth = true)_                                            |       'Hub'       |
-| edge_cert_template  |   \<str\>    | Certificate name on Edge _(when cert_auth = true)_                                            |      'Edge'       |
-| psk                 |   \<str\>    | Pre-shared secret for IKE/IPSEC _(when cert_auth = false)_                                    |     'S3cr3t!'     |
-| overlay_stickiness  | true / false | Generate "overlay stickiness" policy routes on the Hubs _("BGP on Loopback" only)_            |       true        |
-| multireg_advpn      | true / false | Extend ADVPN across the regions                                                               |       false       |
-| hub_hc_server       |    \<ip\>    | Health server IP on the Hubs (set on Lo-HC interface on the Hubs, probed by Edges)            |   '10.200.99.1'   |
+| Parameter              |    Values    | Description                                                                                   |      Default      |
+|:-----------------------|:------------:|:----------------------------------------------------------------------------------------------|:-----------------:|
+| create_hub2hub_zone    | true / false | Create System Zone for inter-regional Hub-to-Hub tunnels                                      |       true        |
+| hub2hub_zone           |   \<str\>    | Name of System Zone for inter-regional Hub-to-Hub tunnels _(when create_hub2hub_zone = true)_ | 'hub2hub_overlay' |
+| create_lan_zone        | true / false | Create System Zone for LAN interfaces (with 'role' = 'lan' in the profile)                    |       true        |
+| lan_zone               |   \<str\>    | Name of System Zone for LAN interfaces _(when create_lan_zone = true)_                        |    'lan_zone'     |
+| create_lan_dhcp_server | true / false | Configure DHCP Servers on LAN interfaces                                                      |       true
+| cert_auth              | true / false | Certificate-based auth for IKE/IPSEC                                                          |       true        |
+| hub_cert_template      |   \<str\>    | Certificate name on Hubs _(when cert_auth = true)_                                            |       'Hub'       |
+| edge_cert_template     |   \<str\>    | Certificate name on Edge _(when cert_auth = true)_                                            |      'Edge'       |
+| psk                    |   \<str\>    | Pre-shared secret for IKE/IPSEC _(when cert_auth = false)_                                    |     'S3cr3t!'     |
+| overlay_stickiness     | true / false | Generate "overlay stickiness" policy routes on the Hubs _("BGP on Loopback" only)_            |       true        |
+| multireg_advpn         | true / false | Extend ADVPN across the regions                                                               |       false       |
+| hub_hc_server          |    \<ip\>    | Health server IP on the Hubs (set on Lo-HC interface on the Hubs, probed by Edges)            |   '10.200.99.1'   |
 
 
 #### Additional parameters for the Multi-VRF flavor

--- a/bgp-on-loopback-multi-vrf/01-Edge-Underlay.j2
+++ b/bgp-on-loopback-multi-vrf/01-Edge-Underlay.j2
@@ -201,6 +201,7 @@ end
 {% endif %}
 
 {# Enable DHCP Server on LAN interfaces #}
+{% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
   {% if i.dhcp_server|default(true) %}
@@ -219,3 +220,4 @@ config system dhcp server
   {% endif %}
   {% endfor %}
 end
+{% endif %}

--- a/bgp-on-loopback-multi-vrf/01-Hub-Underlay.j2
+++ b/bgp-on-loopback-multi-vrf/01-Hub-Underlay.j2
@@ -159,6 +159,7 @@ end
 {% endif %}
 
 {# Enable DHCP Server on LAN interfaces #}
+{% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
   {% if i.dhcp_server|default(true) %}
@@ -177,3 +178,4 @@ config system dhcp server
   {% endif %}
   {% endfor %}
 end
+{% endif %}

--- a/bgp-on-loopback-multi-vrf/projects/Project.j2
+++ b/bgp-on-loopback-multi-vrf/projects/Project.j2
@@ -30,6 +30,7 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+{% set create_lan_dhcp_server = true %}
 
 {% set create_vrf_leak_zone = true %}
 {% set vrf_leak_zone = 'vrfs_leak_zone' %}

--- a/bgp-on-loopback-multi-vrf/projects/Project.nocert.j2
+++ b/bgp-on-loopback-multi-vrf/projects/Project.nocert.j2
@@ -30,6 +30,7 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+{% set create_lan_dhcp_server = true %}
 
 {% set create_vrf_leak_zone = true %}
 {% set vrf_leak_zone = 'vrfs_leak_zone' %}

--- a/bgp-on-loopback/01-Edge-Underlay.j2
+++ b/bgp-on-loopback/01-Edge-Underlay.j2
@@ -119,6 +119,7 @@ end
 {% endif %}
 
 {# Enable DHCP Server on LAN interfaces #}
+{% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
   {% if i.dhcp_server|default(true) %}
@@ -137,3 +138,4 @@ config system dhcp server
   {% endif %}
   {% endfor %}
 end
+{% endif %}

--- a/bgp-on-loopback/01-Hub-Underlay.j2
+++ b/bgp-on-loopback/01-Hub-Underlay.j2
@@ -77,6 +77,7 @@ end
 {% endif %}
 
 {# Enable DHCP Server on LAN interfaces #}
+{% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
   {% if i.dhcp_server|default(true) %}
@@ -95,3 +96,4 @@ config system dhcp server
   {% endif %}
   {% endfor %}
 end
+{% endif %}

--- a/bgp-on-loopback/projects/Project.j2
+++ b/bgp-on-loopback/projects/Project.j2
@@ -29,6 +29,7 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+{% set create_lan_dhcp_server = true %}
 
 {% set cert_auth = true %}
 {% set hub_cert_template = 'Hub' %}

--- a/bgp-on-loopback/projects/Project.nocert.j2
+++ b/bgp-on-loopback/projects/Project.nocert.j2
@@ -29,6 +29,7 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+{% set create_lan_dhcp_server = true %}
 
 {% set cert_auth = true %}
 {% set hub_cert_template = 'Hub' %}

--- a/bgp-per-overlay/01-Edge-Underlay.j2
+++ b/bgp-per-overlay/01-Edge-Underlay.j2
@@ -119,6 +119,7 @@ end
 {% endif %}
 
 {# Enable DHCP Server on LAN interfaces #}
+{% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
   {% if i.dhcp_server|default(true) %}
@@ -137,3 +138,4 @@ config system dhcp server
   {% endif %}
   {% endfor %}
 end
+{% endif %}

--- a/bgp-per-overlay/01-Hub-Underlay.j2
+++ b/bgp-per-overlay/01-Hub-Underlay.j2
@@ -77,6 +77,7 @@ end
 {% endif %}
 
 {# Enable DHCP Server on LAN interfaces #}
+{% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
   {% if i.dhcp_server|default(true) %}
@@ -95,3 +96,4 @@ config system dhcp server
   {% endif %}
   {% endfor %}
 end
+{% endif %}

--- a/bgp-per-overlay/projects/Project.j2
+++ b/bgp-per-overlay/projects/Project.j2
@@ -29,6 +29,7 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+{% set create_lan_dhcp_server = true %}
 
 {% set cert_auth = true %}
 {% set hub_cert_template = 'Hub' %}

--- a/bgp-per-overlay/projects/Project.nocert.j2
+++ b/bgp-per-overlay/projects/Project.nocert.j2
@@ -29,6 +29,7 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+{% set create_lan_dhcp_server = true %}
 
 {% set cert_auth = true %}
 {% set hub_cert_template = 'Hub' %}


### PR DESCRIPTION
Add global "switch" for configuring DHCP Servers on LAN interfaces:

```
{# Enable DHCP Server on LAN interfaces #}
{% if project.create_lan_dhcp_server|default(true) %}   <<<<<<<<
config system dhcp server
```

Note: if this parameter is "true", individual interfaces can still be excluded by setting `dhcp_server: false` in the profile, on per-interface basis.