### PR TITLE
add support for deployment without ADVPN (set intrareg_advpn = false)

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -228,13 +228,14 @@ they are not configured explicitly):
 | hub2hub_zone           |   \<str\>    | Name of System Zone for inter-regional Hub-to-Hub tunnels _(when create_hub2hub_zone = true)_ | 'hub2hub_overlay' |
 | create_lan_zone        | true / false | Create System Zone for LAN interfaces (with 'role' = 'lan' in the profile)                    |       true        |
 | lan_zone               |   \<str\>    | Name of System Zone for LAN interfaces _(when create_lan_zone = true)_                        |    'lan_zone'     |
-| create_lan_dhcp_server | true / false | Configure DHCP Servers on LAN interfaces                                                      |       true
+| create_lan_dhcp_server | true / false | Configure DHCP Servers on LAN interfaces                                                      |       true        |
 | cert_auth              | true / false | Certificate-based auth for IKE/IPSEC                                                          |       true        |
 | hub_cert_template      |   \<str\>    | Certificate name on Hubs _(when cert_auth = true)_                                            |       'Hub'       |
 | edge_cert_template     |   \<str\>    | Certificate name on Edge _(when cert_auth = true)_                                            |      'Edge'       |
 | psk                    |   \<str\>    | Pre-shared secret for IKE/IPSEC _(when cert_auth = false)_                                    |     'S3cr3t!'     |
 | overlay_stickiness     | true / false | Generate "overlay stickiness" policy routes on the Hubs _("BGP on Loopback" only)_            |       true        |
 | intrareg_hub2hub       | true / false | Build intra-regional Hub-to-Hub tunnels for DC-to-DC traffic _("BGP on Loopback" only)_       |       false       |
+| intrareg_advpn         | true / false | Enable ADVPN within each region                                                               |       true        |
 | multireg_advpn         | true / false | Extend ADVPN across the regions                                                               |       false       |
 | hub_hc_server          |    \<ip\>    | Health server IP on the Hubs (set on Lo-HC interface on the Hubs, probed by Edges)            |   '10.200.99.1'   |
 

--- a/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
+++ b/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
@@ -27,10 +27,15 @@ config vpn ipsec phase1-interface
     set net-device enable
     set proposal aes256gcm-prfsha256
     set idle-timeout enable
+    {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-receiver enable
+    set add-route disable
+    {% else %}
+    set auto-discovery-receiver disable    
+    set exchange-interface-ip enable
+    {% endif %}    
     set encapsulation vpn-id-ipip
     set exchange-ip-addr4 {{ loopback|ipaddr('address') }}
-    set add-route disable
     set network-overlay enable
     set network-id {{ project.hubs[h].overlays[i.ol_type].network_id }}
     set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}

--- a/bgp-on-loopback-multi-vrf/02-Hub-Overlay.j2
+++ b/bgp-on-loopback-multi-vrf/02-Hub-Overlay.j2
@@ -16,7 +16,12 @@ config vpn ipsec phase1-interface
     {% endif %}
     set peertype any
     set proposal aes256gcm-prfsha256
+    {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-sender enable
+    {% else %}
+    set auto-discovery-sender disable
+    set exchange-interface-ip enable
+    {% endif %}    
     set encapsulation vpn-id-ipip
     set exchange-ip-addr4 {{ loopback|ipaddr('address') }}
     set add-route disable

--- a/bgp-on-loopback-multi-vrf/03-Hub-Routing.j2
+++ b/bgp-on-loopback-multi-vrf/03-Hub-Routing.j2
@@ -40,7 +40,11 @@ config router bgp
       set remote-as {{ project.regions[region].as }}
       set interface "Lo"
       set update-source "Lo"
+      {% if project.intrareg_advpn|default(true) %}
       set route-reflector-client-vpnv4 enable
+      {% else %}
+      set route-reflector-client-vpnv4 disable
+      {% endif %}      
     next
   end
   config neighbor-range

--- a/bgp-on-loopback-multi-vrf/projects/Project.dualreg.cert.comments.j2
+++ b/bgp-on-loopback-multi-vrf/projects/Project.dualreg.cert.comments.j2
@@ -44,6 +44,7 @@
 {% set psk = 'S3cr3t!' %}
 
 {% set overlay_stickiness = true %}
+{% set intrareg_advpn = true %}
 {% set multireg_advpn = false %}
 {% set hub_hc_server = '10.200.99.1' %}
 #}

--- a/bgp-on-loopback/02-Edge-Overlay.j2
+++ b/bgp-on-loopback/02-Edge-Overlay.j2
@@ -25,9 +25,14 @@ config vpn ipsec phase1-interface
     set net-device enable
     set proposal aes256gcm-prfsha256
     set idle-timeout enable
+    {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-receiver enable
-    set exchange-ip-addr4 {{ loopback|ipaddr('address') }}
     set add-route disable
+    {% else %}
+    set auto-discovery-receiver disable
+    set exchange-interface-ip enable
+    {% endif %}
+    set exchange-ip-addr4 {{ loopback|ipaddr('address') }}
     set network-overlay enable
     set network-id {{ project.hubs[h].overlays[i.ol_type].network_id }}
     set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}

--- a/bgp-on-loopback/02-Hub-Overlay.j2
+++ b/bgp-on-loopback/02-Hub-Overlay.j2
@@ -14,9 +14,14 @@ config vpn ipsec phase1-interface
     {% endif %}
     set peertype any
     set proposal aes256gcm-prfsha256
+    {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-sender enable
-    set exchange-ip-addr4 {{ loopback|ipaddr('address') }}
+    {% else %}
+    set auto-discovery-sender disable
+    set exchange-interface-ip enable
+    {% endif %}    
     set add-route disable
+    set exchange-ip-addr4 {{ loopback|ipaddr('address') }}
     set network-overlay enable
     set network-id {{ project.hubs[hostname].overlays[i.ol_type].network_id }}
     set dpd-retrycount 2

--- a/bgp-on-loopback/03-Hub-Routing.j2
+++ b/bgp-on-loopback/03-Hub-Routing.j2
@@ -37,7 +37,11 @@ config router bgp
       set remote-as {{ project.regions[region].as }}
       set interface "Lo"
       set update-source "Lo"
+      {% if project.intrareg_advpn|default(true) %}
       set route-reflector-client enable
+      {% else %}
+      set route-reflector-client disable
+      {% endif %}
     next
   end
   config neighbor-range

--- a/bgp-per-overlay/02-Edge-Overlay.j2
+++ b/bgp-per-overlay/02-Edge-Overlay.j2
@@ -19,8 +19,13 @@ config vpn ipsec phase1-interface
     set mode-cfg enable
     set proposal aes256gcm-prfsha256
     set idle-timeout enable
+    {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-receiver enable
     set add-route disable
+    {% else %}
+    set auto-discovery-receiver disable
+    set exchange-interface-ip enable
+    {% endif %}
     set network-overlay enable
     set network-id {{ project.hubs[h].overlays[i.ol_type].network_id }}
     set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}

--- a/bgp-per-overlay/02-Hub-Overlay.j2
+++ b/bgp-per-overlay/02-Hub-Overlay.j2
@@ -15,7 +15,12 @@ config vpn ipsec phase1-interface
     set peertype any
     set mode-cfg enable
     set proposal aes256gcm-prfsha256
+    {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-sender enable
+    {% else %}
+    set auto-discovery-sender disable
+    set exchange-interface-ip enable
+    {% endif %}       
     set add-route disable
     set network-overlay enable
     set network-id {{ project.hubs[hostname].overlays[i.ol_type].network_id }}

--- a/bgp-per-overlay/03-Hub-Routing.j2
+++ b/bgp-per-overlay/03-Hub-Routing.j2
@@ -29,7 +29,11 @@ config router bgp
       set remote-as {{ project.regions[region].as }}
       set additional-path send
       set adv-additional-path 255
+      {% if project.intrareg_advpn|default(true) %}
       set route-reflector-client enable
+      {% else %}
+      set route-reflector-client disable
+      {% endif %}      
     next
   end
   config neighbor-range

--- a/bgp-per-overlay/projects/Project.dualreg.cert.comments.j2
+++ b/bgp-per-overlay/projects/Project.dualreg.cert.comments.j2
@@ -36,6 +36,7 @@
 {% set edge_cert_template = 'Edge' %}
 {% set psk = 'S3cr3t!' %}
 
+{% set intrareg_advpn = true %}
 {% set multireg_advpn = false %}
 {% set hub_hc_server = '10.200.99.1' %}
 #}


### PR DESCRIPTION
New optional variable in Project Template:

```
{% set intrareg_advpn = true %}
```

Default value: "true"
When set to "false", ADVPN is not configured within the regions. 

Supports seamless state swap (i.e. move from ADVPN to non-ADVPN and vice versa)