### PR TITLE
support optional ul_name in profiles

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -100,6 +100,8 @@ local topology and the connectivity options for each site:
 %}
 ```
 
+NOTE: All the Edge devices and the Hubs must be assigned a profile!
+
 Apart from the list of interfaces, the profile can also specify that a device is in HA cluster mode:
 
 | Parameter | Values | Description                           | Example |
@@ -145,6 +147,7 @@ each device interface:
 | Parameter       | Values  | Description                                            |    Example     |
 |:----------------|:-------:|:-------------------------------------------------------|:--------------:|
 | ol_type         | \<str\> | Overlay to connect to over this interface*             |     'ISP1'     |
+| ul_name         | \<str\> | Local underlay transport name _(optional)_             |     'ISP1'     |
 | outbandwidth    | \<int\> | Total egress bandwidth _(optional)_                    |     '8000'     |
 | inbandwidth     | \<int\> | Total ingress bandwidth _(optional)_                   |     '8000'     |
 | shaping_profile | \<str\> | Shaping profile to apply _(optional)_                  | 'Edge_Shaping' |
@@ -172,6 +175,31 @@ each device interface:
 
 \* - We provide Internet access for CE VRFs by configuring VRF leaking into the PE VRF (where all underlays and overlays are located).
 \*\* - Leave empty for VM and non-ASIC models in order to use software VDOM links.
+
+
+### Overlay tunnel naming convention
+
+An overlay tunnel will be generated from each WAN-facing interface in the Edge device profile to each Hub 
+serving the device region. The target overlay (to which the tunnel will connect) is defined by the 
+`ol_type` parameter. The default naming convention for the generated tunnels on the Edge device is:
+
+```
+H<hub_index>_<ol_type>
+```
+
+Optionally, a local underlay transport name can be added. This happens automatically, if the `ul_name` 
+parameter is defined. The naming convention then becomes:
+
+```
+<ul_name>-H<hub_index>_<ol_type>
+```
+
+On the Hub side, the Dial-Up overlays are generated with the following naming convention:
+
+```
+EDGE_<ol_type>
+```
+
 
 ## Hubs
 

--- a/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
+++ b/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
@@ -7,7 +7,8 @@
 {% set ol_tunnels = [] %}
 {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
   {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
-  {% set ol_tun = "H"~hubloop.index~"_"~i.ol_type %}
+  {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
+  {% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
   {% set count = ol_tunnels|select("equalto", ol_tun)|list|count %}
   {# Tunnel name = 'H<hub_number>_<ol_type>' if no duplicates, otherwise 'H<hub_number>_<ol_type>_<index>' #}
   {% set ol_tun_name = ol_tun if not count else ol_tun~'_'~(count+1) %}

--- a/bgp-on-loopback-multi-vrf/optional/05-Edge-SDWAN.j2
+++ b/bgp-on-loopback-multi-vrf/optional/05-Edge-SDWAN.j2
@@ -34,7 +34,8 @@ config system sdwan
   {% set ol_tunnels = [] %}
   {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
     {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
-    {% set ol_tun = "H"~hubloop.index~"_"~i.ol_type %}
+    {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
+    {% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
     {% set count = ol_tunnels|select("equalto", ol_tun)|list|count %}
     {# Tunnel name = 'H<hub_number>_<ol_type>' if no duplicates, otherwise 'H<hub_number>_<ol_type>_<index>' #}
     {% set ol_tun_name = ol_tun if not count else ol_tun~'_'~(count+1) %}

--- a/bgp-on-loopback/02-Edge-Overlay.j2
+++ b/bgp-on-loopback/02-Edge-Overlay.j2
@@ -5,7 +5,8 @@
 {% set ol_tunnels = [] %}
 {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
   {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
-  {% set ol_tun = "H"~hubloop.index~"_"~i.ol_type %}
+  {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
+  {% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
   {% set count = ol_tunnels|select("equalto", ol_tun)|list|count %}
   {# Tunnel name = 'H<hub_number>_<ol_type>' if no duplicates, otherwise 'H<hub_number>_<ol_type>_<index>' #}
   {% set ol_tun_name = ol_tun if not count else ol_tun~'_'~(count+1) %}

--- a/bgp-on-loopback/optional/05-Edge-SDWAN.j2
+++ b/bgp-on-loopback/optional/05-Edge-SDWAN.j2
@@ -34,7 +34,8 @@ config system sdwan
   {% set ol_tunnels = [] %}
   {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
     {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
-    {% set ol_tun = "H"~hubloop.index~"_"~i.ol_type %}
+    {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
+    {% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
     {% set count = ol_tunnels|select("equalto", ol_tun)|list|count %}
     {# Tunnel name = 'H<hub_number>_<ol_type>' if no duplicates, otherwise 'H<hub_number>_<ol_type>_<index>' #}
     {% set ol_tun_name = ol_tun if not count else ol_tun~'_'~(count+1) %}


### PR DESCRIPTION
Allow an additional (explicit) option to deal with tunnel naming conflicts and at the same time allow adding the local side identifier to the name. 

Whenever `ul_name` is configured for an interface in the device profile, its value will be used in the naming of all the tunnels built from this interface. So that the naming convention becomes:

```
<ul_name>-H<hub_index>_<ol_type>
```

This is optional. If `ul_name` is not set, the naming convention remains as before. 
The automatic indexing mechanism to deal with duplicates remains in place.

`02-Edge-Overlay.j2` change:

```
{% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
{% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
```