### PR TITLE
option to enable exchange-fgt-device-id (7.2.6+)

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -289,7 +289,7 @@ they are not configured explicitly):
 | intrareg_advpn         | true / false | Enable ADVPN within each region                                                               |       true        |
 | multireg_advpn         | true / false | Extend ADVPN across the regions                                                               |       false       |
 | hub_hc_server          |    \<ip\>    | Health server IP on the Hubs (set on Lo-HC interface on the Hubs, probed by Edges)            |   '10.200.99.1'   |
-
+| monitoring_enhancements| true / false | Improved support of monitoring tools (e.g. FortiManager VPN Monitor, FOS 7.2.6+)              |        false      |
 
 #### Additional parameters for the Multi-VRF flavor
 

--- a/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
+++ b/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
@@ -32,6 +32,9 @@ config vpn ipsec phase1-interface
     {% endif %}
     set keylife 28800
     set peertype any
+    {% if project.monitoring_enhancements|default(false) %}
+    set exchange-fgt-device-id enable
+    {% endif %}    
     set net-device enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set idle-timeout enable

--- a/bgp-on-loopback-multi-vrf/02-Hub-Overlay.j2
+++ b/bgp-on-loopback-multi-vrf/02-Hub-Overlay.j2
@@ -22,6 +22,9 @@ config vpn ipsec phase1-interface
     set psksecret {{ project.psk|default('S3cr3t!') }}
     {% endif %}
     set peertype any
+    {% if project.monitoring_enhancements|default(false) %}
+    set exchange-fgt-device-id enable
+    {% endif %}    
     set proposal aes256gcm-prfsha256 aes256-sha256
     {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-sender enable

--- a/bgp-on-loopback-multi-vrf/04-Hub-MultiRegion.j2
+++ b/bgp-on-loopback-multi-vrf/04-Hub-MultiRegion.j2
@@ -28,6 +28,9 @@
           {% endif %}
           set keylife 28800
           set peertype any
+          {% if project.monitoring_enhancements|default(false) %}
+          set exchange-fgt-device-id enable
+          {% endif %}          
           set proposal aes256gcm-prfsha256
           {% if project.multireg_advpn|default(false) %}
           set auto-discovery-sender enable

--- a/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
+++ b/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
@@ -43,6 +43,8 @@
 {% set intrareg_advpn = true %}
 {% set multireg_advpn = false %}
 {% set hub_hc_server = '10.200.99.1' %}
+
+{% set monitoring_enhancements = false %}
 #}
 
 {#  Mandatory Global Definitions #}

--- a/bgp-on-loopback/02-Edge-Overlay.j2
+++ b/bgp-on-loopback/02-Edge-Overlay.j2
@@ -30,6 +30,9 @@ config vpn ipsec phase1-interface
     {% endif %}
     set keylife 28800
     set peertype any
+    {% if project.monitoring_enhancements|default(false) %}
+    set exchange-fgt-device-id enable
+    {% endif %}
     set net-device enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set idle-timeout enable

--- a/bgp-on-loopback/02-Hub-Overlay.j2
+++ b/bgp-on-loopback/02-Hub-Overlay.j2
@@ -20,6 +20,9 @@ config vpn ipsec phase1-interface
     set psksecret {{ project.psk|default('S3cr3t!') }}
     {% endif %}
     set peertype any
+    {% if project.monitoring_enhancements|default(false) %}
+    set exchange-fgt-device-id enable
+    {% endif %}    
     set proposal aes256gcm-prfsha256 aes256-sha256
     {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-sender enable

--- a/bgp-on-loopback/04-Hub-MultiRegion.j2
+++ b/bgp-on-loopback/04-Hub-MultiRegion.j2
@@ -26,6 +26,9 @@
           {% endif %}
           set keylife 28800
           set peertype any
+          {% if project.monitoring_enhancements|default(false) %}
+          set exchange-fgt-device-id enable
+          {% endif %}          
           set proposal aes256gcm-prfsha256
           {% if project.multireg_advpn|default(false) %}
           set auto-discovery-sender enable

--- a/bgp-on-loopback/05-Hub-IntraRegion.j2
+++ b/bgp-on-loopback/05-Hub-IntraRegion.j2
@@ -26,6 +26,9 @@
       {% endif %}
       set keylife 28800
       set peertype any
+      {% if project.monitoring_enhancements|default(false) %}
+      set exchange-fgt-device-id enable
+      {% endif %}      
       set proposal aes256gcm-prfsha256
       set exchange-interface-ip enable
       set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}

--- a/bgp-on-loopback/projects/!Project.comments.j2
+++ b/bgp-on-loopback/projects/!Project.comments.j2
@@ -38,6 +38,8 @@
 {% set intrareg_advpn = true %}
 {% set multireg_advpn = false %}
 {% set hub_hc_server = '10.200.99.1' %}
+
+{% set monitoring_enhancements = false %}
 #}
 
 {#  Mandatory Global Definitions #}

--- a/bgp-per-overlay/02-Edge-Overlay.j2
+++ b/bgp-per-overlay/02-Edge-Overlay.j2
@@ -22,6 +22,9 @@ config vpn ipsec phase1-interface
     {% endif %}
     set keylife 28800
     set peertype any
+    {% if project.monitoring_enhancements|default(false) %}
+    set exchange-fgt-device-id enable
+    {% endif %}    
     set net-device enable
     set mode-cfg enable
     set proposal aes256gcm-prfsha256 aes256-sha256

--- a/bgp-per-overlay/02-Hub-Overlay.j2
+++ b/bgp-per-overlay/02-Hub-Overlay.j2
@@ -20,6 +20,9 @@ config vpn ipsec phase1-interface
     set psksecret {{ project.psk|default('S3cr3t!') }}
     {% endif %}
     set peertype any
+    {% if project.monitoring_enhancements|default(false) %}
+    set exchange-fgt-device-id enable
+    {% endif %}    
     set mode-cfg enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     {% if project.intrareg_advpn|default(true) %}

--- a/bgp-per-overlay/04-Hub-MultiRegion.j2
+++ b/bgp-per-overlay/04-Hub-MultiRegion.j2
@@ -26,6 +26,9 @@
           {% endif %}
           set keylife 28800
           set peertype any
+          {% if project.monitoring_enhancements|default(false) %}
+          set exchange-fgt-device-id enable
+          {% endif %}          
           set proposal aes256gcm-prfsha256
           {% if project.multireg_advpn|default(false) %}
           set auto-discovery-sender enable

--- a/bgp-per-overlay/projects/!Project.comments.j2
+++ b/bgp-per-overlay/projects/!Project.comments.j2
@@ -36,6 +36,8 @@
 {% set intrareg_advpn = true %}
 {% set multireg_advpn = false %}
 {% set hub_hc_server = '10.200.99.1' %}
+
+{% set monitoring_enhancements = false %}
 #}
 
 {#  Mandatory Global Definitions #}


### PR DESCRIPTION
Configure proprietary enhancements to allow better support of FortiManager monitoring functionality. 
Namely, configure the following option (supported from FOS 7.2.6):
https://docs.fortinet.com/document/fortigate/7.2.6/administration-guide/536508

This option enables correct operation of the VPN Monitor's Traffic View in the recent versions of FortiManager. 

This feature is controlled by an optional parameter in the Project Template ("false" by default):

```
{% set monitoring_enhancements = true %}
```