### PR TITLE
option to make loopback reachable across the regions

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -287,7 +287,8 @@ they are not configured explicitly):
 | overlay_stickiness     | true / false | Generate "overlay stickiness" policy routes on the Hubs _("BGP on Loopback" only)_            |       true        |
 | intrareg_hub2hub       | true / false | Build intra-regional Hub-to-Hub tunnels for DC-to-DC traffic _("BGP on Loopback" only)_       |       false       |
 | intrareg_advpn         | true / false | Enable ADVPN within each region                                                               |       true        |
-| multireg_advpn         | true / false | Extend ADVPN across the regions                                                               |       false       |
+| multireg_advpn         | true / false | Extend ADVPN across the regions _(automatically enables "multireg_lo")_                       |       false       |
+| multireg_lo            | true / false | Make loopbacks reachable across the regions _("BGP on Loopback" only)_                        |       false       |
 | hub_hc_server          |    \<ip\>    | Health server IP on the Hubs (set on Lo-HC interface on the Hubs, probed by Edges)            |   '10.200.99.1'   |
 | monitoring_enhancements| true / false | Improved support of monitoring tools (e.g. FortiManager VPN Monitor, FOS 7.2.6+)              |        false      |
 

--- a/bgp-on-loopback-multi-vrf/04-Hub-MultiRegion.j2
+++ b/bgp-on-loopback-multi-vrf/04-Hub-MultiRegion.j2
@@ -110,8 +110,10 @@ config router route-map
         set match-ip-address "LO_REGIONAL_SUMMARY"
         set set-community no-advertise
       next
+      {% if project.multireg_advpn|default(false) %}      
       edit 100
       next
+      {% endif %}
     end
   next
   edit "EDGE_OUT"

--- a/bgp-on-loopback-multi-vrf/04-Hub-MultiRegion.j2
+++ b/bgp-on-loopback-multi-vrf/04-Hub-MultiRegion.j2
@@ -89,7 +89,7 @@ config system zone
 end
 {% endif %}
 
-{% if project.multireg_advpn|default(false) %}
+{% if project.multireg_advpn|default(false) or project.multireg_lo|default(false) %}
 {# Advertise loopback summaries between the regions #}
 config router access-list
   {# Regional loopback summary #}
@@ -130,8 +130,10 @@ config router bgp
   config neighbor-group
     edit "EDGE"
       set route-map-out EDGE_OUT
+      {% if project.multireg_advpn|default(false) %}
       {# Preserve next-hop of prefixes coming from remote regions #}
       set attribute-unchanged-vpnv4 next-hop
+      {% endif %}
     next
   end
   config network
@@ -148,7 +150,8 @@ config router static
     set comment "Regional loopback summary"
   next
 end
-{% else %}
+{% endif %}
+{% if not project.multireg_advpn|default(false) %}
 {# Advertise regional LAN summaries between the regions #}
 config router static
   {% for v in project.regions[region].vrfs %}
@@ -175,11 +178,11 @@ end
 config router route-map
   edit "HUB2HUB_OUT"
     config rule
-      edit 1
+      edit 2
         set match-ip-address "LAN_REGIONAL_SUMMARY"
         unset set-community
       next
-      edit 1000
+      edit 100
         set action deny
       next
     end

--- a/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
+++ b/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
@@ -42,6 +42,7 @@
 {% set overlay_stickiness = true %}
 {% set intrareg_advpn = true %}
 {% set multireg_advpn = false %}
+{% set multireg_lo = false %}
 {% set hub_hc_server = '10.200.99.1' %}
 
 {% set monitoring_enhancements = false %}

--- a/bgp-on-loopback/04-Hub-MultiRegion.j2
+++ b/bgp-on-loopback/04-Hub-MultiRegion.j2
@@ -103,8 +103,10 @@ config router route-map
         set match-ip-address "LO_REGIONAL_SUMMARY"
         set set-community no-advertise
       next
+      {% if project.multireg_advpn|default(false) %}
       edit 100
       next
+      {% endif %}
     end
   next
   edit "EDGE_OUT"

--- a/bgp-on-loopback/04-Hub-MultiRegion.j2
+++ b/bgp-on-loopback/04-Hub-MultiRegion.j2
@@ -82,7 +82,7 @@ config system zone
 end
 {% endif %}
 
-{% if project.multireg_advpn|default(false) %}
+{% if project.multireg_advpn|default(false) or project.multireg_lo|default(false) %}
 {# Advertise loopback summaries between the regions #}
 config router access-list
   {# Regional loopback summary #}
@@ -123,8 +123,10 @@ config router bgp
   config neighbor-group
     edit "EDGE"
       set route-map-out EDGE_OUT
+      {% if project.multireg_advpn|default(false) %}
       {# Preserve next-hop of prefixes coming from remote regions #}
       unset next-hop-self
+      {% endif %}
     next
   end
   config network
@@ -140,7 +142,8 @@ config router static
     set comment "Regional loopback summary"
   next
 end
-{% else %}
+{% endif %}
+{% if not project.multireg_advpn|default(false) %}
 {# Advertise regional LAN summaries between the regions #}
 config router bgp
   config aggregate-address
@@ -162,7 +165,7 @@ end
 config router route-map
   edit "HUB2HUB_OUT"
     config rule
-      edit 1
+      edit 2
         set match-ip-address "LAN_REGIONAL_SUMMARY"
         unset set-community
       next

--- a/bgp-on-loopback/projects/!Project.comments.j2
+++ b/bgp-on-loopback/projects/!Project.comments.j2
@@ -37,6 +37,7 @@
 {% set intrareg_hub2hub = false %}
 {% set intrareg_advpn = true %}
 {% set multireg_advpn = false %}
+{% set multireg_lo = false %}
 {% set hub_hc_server = '10.200.99.1' %}
 
 {% set monitoring_enhancements = false %}


### PR DESCRIPTION
By default, in "BGP on Loopback" design, loopbacks are reachable across the regions whenever ADVPN is extended across the regions (when `multireg_advpn` = true), because the loopbacks are used as BGP next-hops in that case. 

However, in some situations, it may be required to make the loopbacks reachable across the regions, even if ADVPN is not extended. For example, the loopbacks could be used for device management. 

We add an optional parameter to allow this:

```
{% set multireg_lo = true %}
```

The default value is "false", but it implicitly becomes "true" whenever `multireg_advpn` is set to "true" (hence, there is no need to explicitly add both parameters at the same time). 