### PR TITLE
Improve HA switchover support (enable graceful restart)

### DIFF
--- a/bgp-on-loopback-multi-vrf/03-Edge-Routing.j2
+++ b/bgp-on-loopback-multi-vrf/03-Edge-Routing.j2
@@ -37,11 +37,14 @@ config router bgp
   set ibgp-multipath enable
   set recursive-next-hop enable
   set tag-resolve-mode merge
+  set graceful-restart enable
   config neighbor
     {% for h in project.regions[region].hubs %}
     edit {{ project.hubs[h].lo_bgp }}
       set soft-reconfiguration enable
+      set capability-graceful-restart enable
       set soft-reconfiguration-vpnv4 enable
+      set capability-graceful-restart-vpnv4 enable
       set advertisement-interval 1
       set interface "Lo"
       set update-source "Lo"

--- a/bgp-on-loopback-multi-vrf/03-Hub-Routing.j2
+++ b/bgp-on-loopback-multi-vrf/03-Hub-Routing.j2
@@ -39,9 +39,13 @@ config router bgp
   set ebgp-multipath enable
   set recursive-next-hop enable
   set recursive-inherit-priority enable
+  set graceful-restart enable
   config neighbor-group
     edit "EDGE"
+      set soft-reconfiguration enable
+      set capability-graceful-restart enable    
       set soft-reconfiguration-vpnv4 enable
+      set capability-graceful-restart-vpnv4 enable
       set advertisement-interval 1
       set next-hop-self enable
       set remote-as {{ project.regions[region].as }}

--- a/bgp-on-loopback-multi-vrf/04-Hub-MultiRegion.j2
+++ b/bgp-on-loopback-multi-vrf/04-Hub-MultiRegion.j2
@@ -205,8 +205,10 @@ config router bgp
     edit {{ project.hubs[h].lo_bgp }}
       set ebgp-enforce-multihop enable
       set soft-reconfiguration enable
+      set capability-graceful-restart enable    
+      set soft-reconfiguration-vpnv4 enable
+      set capability-graceful-restart-vpnv4 enable      
       set advertisement-interval 1
-      set link-down-failover enable
       set interface "Lo"
       set update-source "Lo"
       {% if project.multireg_advpn|default(false) %}

--- a/bgp-on-loopback/03-Edge-Routing.j2
+++ b/bgp-on-loopback/03-Edge-Routing.j2
@@ -34,10 +34,12 @@ config router bgp
   set ibgp-multipath enable
   set recursive-next-hop enable
   set tag-resolve-mode merge
+  set graceful-restart enable
   config neighbor
     {% for h in project.regions[region].hubs %}
     edit {{ project.hubs[h].lo_bgp }}
       set soft-reconfiguration enable
+      set capability-graceful-restart enable
       set advertisement-interval 1
       set interface "Lo"
       set update-source "Lo"

--- a/bgp-on-loopback/03-Hub-Routing.j2
+++ b/bgp-on-loopback/03-Hub-Routing.j2
@@ -36,9 +36,11 @@ config router bgp
   set ebgp-multipath enable
   set recursive-next-hop enable
   set recursive-inherit-priority enable
+  set graceful-restart enable
   config neighbor-group
     edit "EDGE"
       set soft-reconfiguration enable
+      set capability-graceful-restart enable
       set advertisement-interval 1
       set next-hop-self enable
       set remote-as {{ project.regions[region].as }}

--- a/bgp-on-loopback/04-Hub-MultiRegion.j2
+++ b/bgp-on-loopback/04-Hub-MultiRegion.j2
@@ -186,8 +186,8 @@ config router bgp
     edit {{ project.hubs[h].lo_bgp }}
       set ebgp-enforce-multihop enable
       set soft-reconfiguration enable
+      set capability-graceful-restart enable
       set advertisement-interval 1
-      set link-down-failover enable
       set interface "Lo"
       set update-source "Lo"
       set route-map-out "HUB2HUB_OUT"

--- a/bgp-on-loopback/05-Hub-IntraRegion.j2
+++ b/bgp-on-loopback/05-Hub-IntraRegion.j2
@@ -91,10 +91,12 @@ config router bgp
   {% for h in project.regions[region].hubs if h != hostname %}
   edit {{ project.hubs[h].lo_bgp }}
     set soft-reconfiguration enable
+    set capability-graceful-restart enable
     set advertisement-interval 1
     set remote-as {{ project.regions[region].as }}
     set interface "Lo"
     set update-source "Lo"
+    set connect-timer 1
     set route-map-out "LOCAL_HUB2HUB_OUT"
   next
   {% endfor %}

--- a/bgp-per-overlay/03-Edge-Routing.j2
+++ b/bgp-per-overlay/03-Edge-Routing.j2
@@ -16,12 +16,14 @@ config router bgp
   set additional-path enable
   set additional-path-select 255
   set recursive-next-hop enable
+  set graceful-restart enable
   config neighbor
     {% for h in project.regions[region].hubs %}
     {% set hubloop = loop %}
     {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
     edit {{ project.hubs[h].overlays[i.ol_type].tunnel_net|ipaddr(1)|ipaddr('address') }}
       set soft-reconfiguration enable
+      set capability-graceful-restart enable
       set advertisement-interval 1
       set link-down-failover enable
       set interface "H{{ hubloop.index }}_{{ i.ol_type }}"

--- a/bgp-per-overlay/03-Hub-Routing.j2
+++ b/bgp-per-overlay/03-Hub-Routing.j2
@@ -27,9 +27,11 @@ config router bgp
   set additional-path enable
   set additional-path-select 255
   set recursive-next-hop enable
+  set graceful-restart enable
   config neighbor-group
     edit "EDGE"
       set soft-reconfiguration enable
+      set capability-graceful-restart enable
       set advertisement-interval 1
       set link-down-failover enable
       set next-hop-self enable

--- a/bgp-per-overlay/04-Hub-MultiRegion.j2
+++ b/bgp-per-overlay/04-Hub-MultiRegion.j2
@@ -161,6 +161,7 @@ config router bgp
     edit {{ project.hubs[h].lo_bgp }}
       set ebgp-enforce-multihop enable
       set soft-reconfiguration enable
+      set capability-graceful-restart enable
       set advertisement-interval 1
       set link-down-failover enable
       set interface "Lo"


### PR DESCRIPTION
We enable BGP GR on all Spokes and Hubs. 
Strictly speaking, it is only necessary when there is at least one HA site in the network. But once such a site exists, the GR must be enabled on both sides of the peering (hence, on both the Hub and the Spoke). 
Therefore, a logical solution is to enable it by default, and to keep it HA-ready.