### PR TITLE
fix BGP communities for regions with 4-byte ASN

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -273,24 +273,25 @@ Each parameter can be configured simply as follows:
 The following table lists all the supported parameters, as well as their default values (applied when
 they are not configured explicitly):
 
-| Parameter              |    Values    | Description                                                                                   |      Default      |
-|:-----------------------|:------------:|:----------------------------------------------------------------------------------------------|:-----------------:|
-| create_hub2hub_zone    | true / false | Create System Zone for inter-regional Hub-to-Hub tunnels                                      |       true        |
-| hub2hub_zone           |   \<str\>    | Name of System Zone for inter-regional Hub-to-Hub tunnels _(when create_hub2hub_zone = true)_ | 'hub2hub_overlay' |
-| create_lan_zone        | true / false | Create System Zone for LAN interfaces (with 'role' = 'lan' in the profile)                    |       true        |
-| lan_zone               |   \<str\>    | Name of System Zone for LAN interfaces _(when create_lan_zone = true)_                        |    'lan_zone'     |
-| create_lan_dhcp_server | true / false | Configure DHCP Servers on LAN interfaces                                                      |       true        |
-| cert_auth              | true / false | Certificate-based auth for IKE/IPSEC                                                          |       true        |
-| hub_cert_template      |   \<str\>    | Certificate name on Hubs _(when cert_auth = true)_                                            |       'Hub'       |
-| edge_cert_template     |   \<str\>    | Certificate name on Edge _(when cert_auth = true)_                                            |      'Edge'       |
-| psk                    |   \<str\>    | Pre-shared secret for IKE/IPSEC _(when cert_auth = false)_                                    |     'S3cr3t!'     |
-| overlay_stickiness     | true / false | Generate "overlay stickiness" policy routes on the Hubs _("BGP on Loopback" only)_            |       true        |
-| intrareg_hub2hub       | true / false | Build intra-regional Hub-to-Hub tunnels for DC-to-DC traffic _("BGP on Loopback" only)_       |       false       |
-| intrareg_advpn         | true / false | Enable ADVPN within each region                                                               |       true        |
-| multireg_advpn         | true / false | Extend ADVPN across the regions _(automatically enables "multireg_lo")_                       |       false       |
-| multireg_lo            | true / false | Make loopbacks reachable across the regions _("BGP on Loopback" only)_                        |       false       |
-| hub_hc_server          |    \<ip\>    | Health server IP on the Hubs (set on Lo-HC interface on the Hubs, probed by Edges)            |   '10.200.99.1'   |
-| monitoring_enhancements| true / false | Improved support of monitoring tools (e.g. FortiManager VPN Monitor, FOS 7.2.6+)              |        false      |
+| Parameter               |    Values    | Description                                                                                                  |      Default      |
+|:------------------------|:------------:|:-------------------------------------------------------------------------------------------------------------|:-----------------:|
+| create_hub2hub_zone     | true / false | Create System Zone for inter-regional Hub-to-Hub tunnels                                                     |       true        |
+| hub2hub_zone            |   \<str\>    | Name of System Zone for inter-regional Hub-to-Hub tunnels _(when create_hub2hub_zone = true)_                | 'hub2hub_overlay' |
+| create_lan_zone         | true / false | Create System Zone for LAN interfaces (with 'role' = 'lan' in the profile)                                   |       true        |
+| lan_zone                |   \<str\>    | Name of System Zone for LAN interfaces _(when create_lan_zone = true)_                                       |    'lan_zone'     |
+| create_lan_dhcp_server  | true / false | Configure DHCP Servers on LAN interfaces                                                                     |       true        |
+| cert_auth               | true / false | Certificate-based auth for IKE/IPSEC                                                                         |       true        |
+| hub_cert_template       |   \<str\>    | Certificate name on Hubs _(when cert_auth = true)_                                                           |       'Hub'       |
+| edge_cert_template      |   \<str\>    | Certificate name on Edge _(when cert_auth = true)_                                                           |      'Edge'       |
+| psk                     |   \<str\>    | Pre-shared secret for IKE/IPSEC _(when cert_auth = false)_                                                   |     'S3cr3t!'     |
+| overlay_stickiness      | true / false | Generate "overlay stickiness" policy routes on the Hubs _("BGP on Loopback" only)_                           |       true        |
+| intrareg_hub2hub        | true / false | Build intra-regional Hub-to-Hub tunnels for DC-to-DC traffic _("BGP on Loopback" only)_                      |       false       |
+| intrareg_advpn          | true / false | Enable ADVPN within each region                                                                              |       true        |
+| multireg_advpn          | true / false | Extend ADVPN across the regions _(automatically enables "multireg_lo")_                                      |       false       |
+| multireg_lo             | true / false | Make loopbacks reachable across the regions _("BGP on Loopback" only)_                                       |       false       |
+| hub_hc_server           |    \<ip\>    | Health server IP on the Hubs (set on Lo-HC interface on the Hubs, probed by Edges)                           |   '10.200.99.1'   |
+| short_community_as      |   \<asn\>    | Fictitious Autonomous System number for BGP communities in regions with 4-byte AS _("BGP on Loopback" only)_ |      '65000'      |
+| monitoring_enhancements | true / false | Improved support of monitoring tools (e.g. FortiManager VPN Monitor, FOS 7.2.6+)                             |       false       |
 
 #### Additional parameters for the Multi-VRF flavor
 

--- a/bgp-on-loopback-multi-vrf/03-Edge-Routing.j2
+++ b/bgp-on-loopback-multi-vrf/03-Edge-Routing.j2
@@ -9,6 +9,8 @@
 
 {% set pe_vrf = project.regions[region].pe_vrf|default(1) %}
 {% set vrf_rt_as = project.vrf_rt_as|default('65000') %}
+{# For regions with 4-byte ASN, use a dummy 2-byte ASN for BGP communities (4-byte ASN is not supported in communities) #}
+{% set community_as = project.regions[region].as if project.regions[region].as|int < 65536 else project.short_community_as|default('65000') %}
 
 config router route-map
   {% for i in range(1,3) %}
@@ -23,7 +25,7 @@ config router route-map
   edit "SLA_OK"
     config rule
       edit 1
-        set set-community "{{ project.regions[region].as }}:99"
+        set set-community "{{ community_as }}:99"
       next
     end
   next

--- a/bgp-on-loopback-multi-vrf/03-Hub-Routing.j2
+++ b/bgp-on-loopback-multi-vrf/03-Hub-Routing.j2
@@ -9,13 +9,15 @@
 
 {% set pe_vrf = project.regions[region].pe_vrf|default(1) %}
 {% set vrf_rt_as = project.vrf_rt_as|default('65000') %}
+{# For regions with 4-byte ASN, use a dummy 2-byte ASN for BGP communities (4-byte ASN is not supported in communities) #}
+{% set community_as = project.regions[region].as if project.regions[region].as|int < 65536 else project.short_community_as|default('65000') %}
 
 config router community-list
   edit "SLA_OK"
     config rule
       edit 1
         set action permit
-        set match "{{ project.regions[region].as }}:99"
+        set match "{{ community_as }}:99"
       next
     end
   next

--- a/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
+++ b/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
@@ -45,6 +45,7 @@
 {% set multireg_lo = false %}
 {% set hub_hc_server = '10.200.99.1' %}
 
+{% set short_community_as = '65000' %}
 {% set monitoring_enhancements = false %}
 #}
 

--- a/bgp-on-loopback/03-Edge-Routing.j2
+++ b/bgp-on-loopback/03-Edge-Routing.j2
@@ -7,6 +7,9 @@
 
 {% import 'Project' as project with context %}
 
+{# For regions with 4-byte ASN, use a dummy 2-byte ASN for BGP communities (4-byte ASN is not supported in communities) #}
+{% set community_as = project.regions[region].as if project.regions[region].as|int < 65536 else project.short_community_as|default('65000') %}
+
 config router route-map
   {% for i in range(1,3) %}
   edit "H{{loop.index}}_TAG"
@@ -20,7 +23,7 @@ config router route-map
   edit "SLA_OK"
     config rule
       edit 1
-        set set-community "{{ project.regions[region].as }}:99"
+        set set-community "{{ community_as }}:99"
       next
     end
   next

--- a/bgp-on-loopback/03-Hub-Routing.j2
+++ b/bgp-on-loopback/03-Hub-Routing.j2
@@ -7,12 +7,15 @@
 
 {% import 'Project' as project with context %}
 
+{# For regions with 4-byte ASN, use a dummy 2-byte ASN for BGP communities (4-byte ASN is not supported in communities) #}
+{% set community_as = project.regions[region].as if project.regions[region].as|int < 65536 else project.short_community_as|default('65000') %}
+
 config router community-list
   edit "SLA_OK"
     config rule
       edit 1
         set action permit
-        set match "{{ project.regions[region].as }}:99"
+        set match "{{ community_as }}:99"
       next
     end
   next

--- a/bgp-on-loopback/05-Hub-IntraRegion.j2
+++ b/bgp-on-loopback/05-Hub-IntraRegion.j2
@@ -7,6 +7,9 @@
 
 {% import 'Project' as project with context %}
 
+{# For regions with 4-byte ASN, use a dummy 2-byte ASN for BGP communities (4-byte ASN is not supported in communities) #}
+{% set community_as = project.regions[region].as if project.regions[region].as|int < 65536 else project.short_community_as|default('65000') %}
+
 {# Hub2Hub tunnels within the region (for DC-to-DC traffic) #}
 {% set my_index = project.regions[region].hubs.index(hostname) + 1 %}
 {% if project.intrareg_hub2hub|default(false) %}
@@ -63,7 +66,7 @@ config router community-list
     config rule
       edit 1
         set action permit
-        set match "{{ project.regions[region].as }}:95"
+        set match "{{ community_as }}:95"
       next
     end    
   next
@@ -72,7 +75,7 @@ config router route-map
   edit "HUB_IN"
     config rule
       edit 1
-        set set-community "{{ project.regions[region].as }}:95"
+        set set-community "{{ community_as }}:95"
       next
     end
   next

--- a/bgp-on-loopback/projects/!Project.comments.j2
+++ b/bgp-on-loopback/projects/!Project.comments.j2
@@ -40,6 +40,7 @@
 {% set multireg_lo = false %}
 {% set hub_hc_server = '10.200.99.1' %}
 
+{% set short_community_as = '65000' %}
 {% set monitoring_enhancements = false %}
 #}
 


### PR DESCRIPTION
FOS supports 4-byte Autonomous System Numbers (ASNs), but it doesn't support using them in BGP communities (rfc5668). 

For this reason, a new optional parameter is introduced:

```
{% set short_community_as = '65000' %}
```

Its effect is the following:
- For regions with `as` < 65536 (2-byte ASN), this parameter is ignored. The actual ASN of the region is used in the BGP communities applied by Jinja.
- For regions with `as` >= 65536 (4-byte ASN), this parameter is used in BGP communities applied by Jinja.

For example, Jinja applies the following community (in "03-Edge-Routing.j2" and "03-Hub-Routing.j2"):

```
  edit "SLA_OK"
    config rule
      edit 1
        set set-community "{{ community_as }}:99"
      next
    end
  next
```

For a region with a 2-byte ASN = 65001, the SLA_OK community will simply have a value of "65001:99".
For a region with a 4-byte ASN > 65536, the SLA_OK community will use the new parameter. Its default value is "65000", so that the SLA_OK community will, by default, have a value of "65000:99" for such regions.
