### PR TITLE
support underlay loopback (src_ip for local-out traffic)

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -144,14 +144,15 @@ each device interface:
 
 #### Additional parameters for WAN-facing interfaces
 
-| Parameter       | Values  | Description                                            |    Example     |
-|:----------------|:-------:|:-------------------------------------------------------|:--------------:|
-| ol_type         | \<str\> | Overlay to connect to over this interface*             |     'ISP1'     |
-| ul_name         | \<str\> | Local underlay transport name _(optional)_             |     'ISP1'     |
-| outbandwidth    | \<int\> | Total egress bandwidth _(optional)_                    |     '8000'     |
-| inbandwidth     | \<int\> | Total ingress bandwidth _(optional)_                   |     '8000'     |
-| shaping_profile | \<str\> | Shaping profile to apply _(optional)_                  | 'Edge_Shaping' |
-| dia             |  true   | Interface used for Direct Internet Access _(optional)_ |                |
+| Parameter       |   Values    | Description                                                    |    Example     |
+|:----------------|:-----------:|:---------------------------------------------------------------|:--------------:|
+| ol_type         |   \<str\>   | Overlay to connect to over this interface*                     |     'ISP1'     |
+| ul_name         |   \<str\>   | Local underlay transport name _(optional)_                     |     'ISP1'     |
+| src_ip          | \<ip/mask\> | Source IP for all local-out traffic (incl. IPSEC) _(optional)_ |  '1.2.3.4/32'  |
+| outbandwidth    |   \<int\>   | Total egress bandwidth _(optional)_                            |     '8000'     |
+| inbandwidth     |   \<int\>   | Total ingress bandwidth _(optional)_                           |     '8000'     |
+| shaping_profile |   \<str\>   | Shaping profile to apply _(optional)_                          | 'Edge_Shaping' |
+| dia             |    true     | Interface used for Direct Internet Access _(optional)_         |                |
 
 \* - The overlay types referenced here must correspond to those defined in the Hub dictionary [below](#hubs)
 

--- a/bgp-on-loopback-multi-vrf/01-Edge-Underlay.j2
+++ b/bgp-on-loopback-multi-vrf/01-Edge-Underlay.j2
@@ -167,6 +167,19 @@ end
   {% endif %}
 {% endif %}
 
+{# Configure underlay loopback for local-out traffic (e.g. IPSEC src) #}
+{% if i.role == 'wan' and i.src_ip is defined %}
+config system interface
+  edit "Lo-wan{{ loop.index }}"
+    set vdom "root"
+    set type loopback
+    set vrf {{ pe_vrf }}
+    set ip {{ i.src_ip }}
+    set allowaccess ping
+  next
+end
+{% endif %}
+
 {# End Loop: Configure underlay interfaces #}
 {% endfor %}
 

--- a/bgp-on-loopback-multi-vrf/01-Hub-Underlay.j2
+++ b/bgp-on-loopback-multi-vrf/01-Hub-Underlay.j2
@@ -133,6 +133,19 @@ end
   {% endif %}
 {% endif %}
 
+{# Configure underlay loopback for local-out traffic (e.g. IPSEC src) #}
+{% if i.role == 'wan' and i.src_ip is defined %}
+config system interface
+  edit "Lo-wan{{ loop.index }}"
+    set vdom "root"
+    set type loopback
+    set vrf {{ pe_vrf }}
+    set ip {{ i.src_ip }}
+    set allowaccess ping
+  next
+end
+{% endif %}
+
 {# End Loop: Configure underlay interfaces #}
 {% endfor %}
 

--- a/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
+++ b/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
@@ -50,6 +50,9 @@ config vpn ipsec phase1-interface
     set network-overlay enable
     set network-id {{ project.hubs[h].overlays[i.ol_type].network_id }}
     set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}
+    {% if i.src_ip is defined %}
+    set local-gw {{ i.src_ip|ipaddr('address') }}
+    {% endif %}    
     set dpd-retrycount 3
     set dpd-retryinterval 5
     set dpd on-idle

--- a/bgp-on-loopback-multi-vrf/02-Hub-Overlay.j2
+++ b/bgp-on-loopback-multi-vrf/02-Hub-Overlay.j2
@@ -37,6 +37,9 @@ config vpn ipsec phase1-interface
     set add-route disable
     set network-overlay enable
     set network-id {{ project.hubs[hostname].overlays[i.ol_type].network_id }}
+    {% if i.src_ip is defined %}
+    set local-gw {{ i.src_ip|ipaddr('address') }}
+    {% endif %}    
     set dpd-retrycount 2
     set dpd-retryinterval 5
     set dpd on-idle

--- a/bgp-on-loopback-multi-vrf/optional/05-Edge-SDWAN.j2
+++ b/bgp-on-loopback-multi-vrf/optional/05-Edge-SDWAN.j2
@@ -29,6 +29,9 @@ config system sdwan
     edit {{ ns.mbr_i }}
       set interface "{{ i.name }}"
       set zone "underlay"
+      {% if i.src_ip is defined %}
+      set source {{ i.src_ip }}
+      {% endif %}      
       # Best priority, used for Internet access in implicit rule / local-out
       # Gateway is fetched from DHCP
     next

--- a/bgp-on-loopback-multi-vrf/optional/05-Hub-SDWAN.j2
+++ b/bgp-on-loopback-multi-vrf/optional/05-Hub-SDWAN.j2
@@ -22,6 +22,9 @@ config system sdwan
     edit {{ ns.mbr_i }}
       set interface "{{ i.name }}"
       set zone "underlay"
+      {% if i.src_ip is defined %}
+      set source {{ i.src_ip }}
+      {% endif %}      
       # Gateway is fetched from DHCP
     next
     {% set ns.mbr_i = ns.mbr_i + 1 %}

--- a/bgp-on-loopback-multi-vrf/optional/06-Edge-Firewall.j2
+++ b/bgp-on-loopback-multi-vrf/optional/06-Edge-Firewall.j2
@@ -90,4 +90,23 @@ config firewall policy
     set schedule "always"
     set service "PING"
   next
+  {# Permit incoming traffic to underlay loopback, when used #}
+  {% set lo_wan = [] %}
+  {% for i in project.profiles[profile].interfaces if i.name is defined %}
+    {% if i.src_ip is defined %}
+    {{ lo_wan.append("Lo-wan"~loop.index) or "" }}
+    {% endif %}
+  {% endfor %}
+  {% if lo_wan|count %}
+  edit 5
+    set name "Underlay Loopback"
+    set srcintf "underlay"
+    set dstintf {{ lo_wan|join(' ') }}
+    set srcaddr "all"
+    set dstaddr "all"
+    set action accept
+    set schedule "always"
+    set service "ALL"
+  next  
+  {% endif %}  
 end

--- a/bgp-on-loopback-multi-vrf/optional/06-Hub-Firewall.j2
+++ b/bgp-on-loopback-multi-vrf/optional/06-Hub-Firewall.j2
@@ -90,4 +90,23 @@ config firewall policy
     set schedule "always"
     set service "PING" "BGP"
   next
+  {# Permit incoming traffic to underlay loopback, when used #}
+  {% set lo_wan = [] %}
+  {% for i in project.profiles[profile].interfaces if i.name is defined %}
+    {% if i.src_ip is defined %}
+    {{ lo_wan.append("Lo-wan"~loop.index) or "" }}
+    {% endif %}
+  {% endfor %}
+  {% if lo_wan|count %}
+  edit 7
+    set name "Underlay Loopback"
+    set srcintf "underlay"
+    set dstintf {{ lo_wan|join(' ') }}
+    set srcaddr "all"
+    set dstaddr "all"
+    set action accept
+    set schedule "always"
+    set service "ALL"
+  next  
+  {% endif %}    
 end

--- a/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
+++ b/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
@@ -86,6 +86,7 @@
           'name': ,
           'role': ,
           'ip': ,
+          'src_ip': ,
           'vlanid': ,
           'parent': ,
           'access': ,

--- a/bgp-on-loopback/01-Edge-Underlay.j2
+++ b/bgp-on-loopback/01-Edge-Underlay.j2
@@ -85,6 +85,18 @@ config system interface
 end
 {% endif %}
 
+{# Configure underlay loopback for local-out traffic (e.g. IPSEC src) #}
+{% if i.src_ip is defined %}
+config system interface
+  edit "Lo-wan{{ loop.index }}"
+    set vdom "root"
+    set type loopback
+    set ip {{ i.src_ip }}
+    set allowaccess ping
+  next
+end
+{% endif %}
+
 {# End Loop: Configure underlay interfaces #}
 {% endfor %}
 

--- a/bgp-on-loopback/01-Edge-Underlay.j2
+++ b/bgp-on-loopback/01-Edge-Underlay.j2
@@ -86,7 +86,7 @@ end
 {% endif %}
 
 {# Configure underlay loopback for local-out traffic (e.g. IPSEC src) #}
-{% if i.src_ip is defined %}
+{% if i.role == 'wan' and i.src_ip is defined %}
 config system interface
   edit "Lo-wan{{ loop.index }}"
     set vdom "root"

--- a/bgp-on-loopback/01-Hub-Underlay.j2
+++ b/bgp-on-loopback/01-Hub-Underlay.j2
@@ -53,7 +53,7 @@ config system interface
 end
 
 {# Configure underlay loopback for local-out traffic (e.g. IPSEC src) #}
-{% if i.src_ip is defined %}
+{% if i.role == 'wan' and i.src_ip is defined %}
 config system interface
   edit "Lo-wan{{ loop.index }}"
     set vdom "root"

--- a/bgp-on-loopback/01-Hub-Underlay.j2
+++ b/bgp-on-loopback/01-Hub-Underlay.j2
@@ -52,6 +52,18 @@ config system interface
   next
 end
 
+{# Configure underlay loopback for local-out traffic (e.g. IPSEC src) #}
+{% if i.src_ip is defined %}
+config system interface
+  edit "Lo-wan{{ loop.index }}"
+    set vdom "root"
+    set type loopback
+    set ip {{ i.src_ip }}
+    set allowaccess ping
+  next
+end
+{% endif %}
+
 {# End Loop: Configure underlay interfaces #}
 {% endfor %}
 

--- a/bgp-on-loopback/02-Edge-Overlay.j2
+++ b/bgp-on-loopback/02-Edge-Overlay.j2
@@ -47,6 +47,9 @@ config vpn ipsec phase1-interface
     set network-overlay enable
     set network-id {{ project.hubs[h].overlays[i.ol_type].network_id }}
     set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}
+    {% if i.src_ip is defined %}
+    set local-gw {{ i.src_ip|ipaddr('address') }}
+    {% endif %}
     set dpd-retrycount 3
     set dpd-retryinterval 5
     set dpd on-idle

--- a/bgp-on-loopback/02-Hub-Overlay.j2
+++ b/bgp-on-loopback/02-Hub-Overlay.j2
@@ -34,6 +34,9 @@ config vpn ipsec phase1-interface
     set exchange-ip-addr4 {{ loopback|ipaddr('address') }}
     set network-overlay enable
     set network-id {{ project.hubs[hostname].overlays[i.ol_type].network_id }}
+    {% if i.src_ip is defined %}
+    set local-gw {{ i.src_ip|ipaddr('address') }}
+    {% endif %}    
     set dpd-retrycount 2
     set dpd-retryinterval 5
     set dpd on-idle

--- a/bgp-on-loopback/optional/05-Edge-SDWAN.j2
+++ b/bgp-on-loopback/optional/05-Edge-SDWAN.j2
@@ -29,6 +29,9 @@ config system sdwan
     edit {{ ns.mbr_i }}
       set interface "{{ i.name }}"
       set zone "underlay"
+      {% if i.src_ip is defined %}
+      set source {{ i.src_ip }}
+      {% endif %}
       # Best priority, used for Internet access in implicit rule / local-out
       # Gateway is fetched from DHCP
     next

--- a/bgp-on-loopback/optional/05-Hub-SDWAN.j2
+++ b/bgp-on-loopback/optional/05-Hub-SDWAN.j2
@@ -22,6 +22,9 @@ config system sdwan
     edit {{ ns.mbr_i }}
       set interface "{{ i.name }}"
       set zone "underlay"
+      {% if i.src_ip is defined %}
+      set source {{ i.src_ip }}
+      {% endif %}
       # Gateway is fetched from DHCP
     next
     {% set ns.mbr_i = ns.mbr_i + 1 %}

--- a/bgp-on-loopback/optional/06-Edge-Firewall.j2
+++ b/bgp-on-loopback/optional/06-Edge-Firewall.j2
@@ -66,4 +66,23 @@ config firewall policy
     set schedule "always"
     set service "PING"
   next
+  {# Permit incoming traffic to underlay loopback, when used #}
+  {% set lo_wan = [] %}
+  {% for i in project.profiles[profile].interfaces if i.name is defined %}
+    {% if i.src_ip is defined %}
+    {{ lo_wan.append("Lo-wan"~loop.index) or "" }}
+    {% endif %}
+  {% endfor %}
+  {% if lo_wan|count %}
+  edit 5
+    set name "Underlay Loopback"
+    set srcintf "underlay"
+    set dstintf {{ lo_wan|join(' ') }}
+    set srcaddr "all"
+    set dstaddr "all"
+    set action accept
+    set schedule "always"
+    set service "ALL"
+  next  
+  {% endif %}
 end

--- a/bgp-on-loopback/optional/06-Hub-Firewall.j2
+++ b/bgp-on-loopback/optional/06-Hub-Firewall.j2
@@ -90,4 +90,23 @@ config firewall policy
     set schedule "always"
     set service "PING" "BGP"
   next
+  {# Permit incoming traffic to underlay loopback, when used #}
+  {% set lo_wan = [] %}
+  {% for i in project.profiles[profile].interfaces if i.name is defined %}
+    {% if i.src_ip is defined %}
+    {{ lo_wan.append("Lo-wan"~loop.index) or "" }}
+    {% endif %}
+  {% endfor %}
+  {% if lo_wan|count %}
+  edit 7
+    set name "Underlay Loopback"
+    set srcintf "underlay"
+    set dstintf {{ lo_wan|join(' ') }}
+    set srcaddr "all"
+    set dstaddr "all"
+    set action accept
+    set schedule "always"
+    set service "ALL"
+  next  
+  {% endif %}  
 end

--- a/bgp-on-loopback/projects/!Project.comments.j2
+++ b/bgp-on-loopback/projects/!Project.comments.j2
@@ -74,6 +74,7 @@
           'name': ,
           'role': ,
           'ip': ,
+          'src_ip': ,
           'vlanid': ,
           'parent': ,
           'access': ,

--- a/bgp-per-overlay/01-Edge-Underlay.j2
+++ b/bgp-per-overlay/01-Edge-Underlay.j2
@@ -85,6 +85,18 @@ config system interface
 end
 {% endif %}
 
+{# Configure underlay loopback for local-out traffic (e.g. IPSEC src) #}
+{% if i.role == 'wan' and i.src_ip is defined %}
+config system interface
+  edit "Lo-wan{{ loop.index }}"
+    set vdom "root"
+    set type loopback
+    set ip {{ i.src_ip }}
+    set allowaccess ping
+  next
+end
+{% endif %}
+
 {# End Loop: Configure underlay interfaces #}
 {% endfor %}
 

--- a/bgp-per-overlay/01-Hub-Underlay.j2
+++ b/bgp-per-overlay/01-Hub-Underlay.j2
@@ -52,6 +52,18 @@ config system interface
   next
 end
 
+{# Configure underlay loopback for local-out traffic (e.g. IPSEC src) #}
+{% if i.role == 'wan' and i.src_ip is defined %}
+config system interface
+  edit "Lo-wan{{ loop.index }}"
+    set vdom "root"
+    set type loopback
+    set ip {{ i.src_ip }}
+    set allowaccess ping
+  next
+end
+{% endif %}
+
 {# End Loop: Configure underlay interfaces #}
 {% endfor %}
 

--- a/bgp-per-overlay/02-Edge-Overlay.j2
+++ b/bgp-per-overlay/02-Edge-Overlay.j2
@@ -39,6 +39,9 @@ config vpn ipsec phase1-interface
     set network-overlay enable
     set network-id {{ project.hubs[h].overlays[i.ol_type].network_id }}
     set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}
+    {% if i.src_ip is defined %}
+    set local-gw {{ i.src_ip|ipaddr('address') }}
+    {% endif %}    
     set dpd-retrycount 3
     set dpd-retryinterval 5
     set dpd on-idle

--- a/bgp-per-overlay/02-Hub-Overlay.j2
+++ b/bgp-per-overlay/02-Hub-Overlay.j2
@@ -37,6 +37,9 @@ config vpn ipsec phase1-interface
     set ipv4-start-ip {{ project.hubs[hostname].overlays[i.ol_type].tunnel_net|ipaddr(2)|ipaddr('address') }}
     set ipv4-end-ip {{ project.hubs[hostname].overlays[i.ol_type].tunnel_net|ipaddr(-3)|ipaddr('address') }}
     set ipv4-netmask {{ project.hubs[hostname].overlays[i.ol_type].tunnel_net|ipaddr('netmask') }}
+    {% if i.src_ip is defined %}
+    set local-gw {{ i.src_ip|ipaddr('address') }}
+    {% endif %}    
     set dpd-retrycount 3
     set dpd-retryinterval 5
     set dpd on-demand

--- a/bgp-per-overlay/optional/05-Edge-SDWAN.j2
+++ b/bgp-per-overlay/optional/05-Edge-SDWAN.j2
@@ -29,6 +29,9 @@ config system sdwan
     edit {{ ns.mbr_i }}
       set interface "{{ i.name }}"
       set zone "underlay"
+      {% if i.src_ip is defined %}
+      set source {{ i.src_ip }}
+      {% endif %}      
       # Best priority, used for Internet access in implicit rule / local-out
       # Gateway is fetched from DHCP
     next

--- a/bgp-per-overlay/optional/05-Hub-SDWAN.j2
+++ b/bgp-per-overlay/optional/05-Hub-SDWAN.j2
@@ -20,6 +20,9 @@ config system sdwan
     edit {{ ns.mbr_i }}
       set interface "{{ i.name }}"
       set zone "underlay"
+      {% if i.src_ip is defined %}
+      set source {{ i.src_ip }}
+      {% endif %}      
       # Gateway is fetched from DHCP
     next
     {% set ns.mbr_i = ns.mbr_i + 1 %}

--- a/bgp-per-overlay/optional/06-Edge-Firewall.j2
+++ b/bgp-per-overlay/optional/06-Edge-Firewall.j2
@@ -56,4 +56,23 @@ config firewall policy
     set application-list "default"
     set logtraffic all
   next
+  {# Permit incoming traffic to underlay loopback, when used #}
+  {% set lo_wan = [] %}
+  {% for i in project.profiles[profile].interfaces if i.name is defined %}
+    {% if i.src_ip is defined %}
+    {{ lo_wan.append("Lo-wan"~loop.index) or "" }}
+    {% endif %}
+  {% endfor %}
+  {% if lo_wan|count %}
+  edit 4
+    set name "Underlay Loopback"
+    set srcintf "underlay"
+    set dstintf {{ lo_wan|join(' ') }}
+    set srcaddr "all"
+    set dstaddr "all"
+    set action accept
+    set schedule "always"
+    set service "ALL"
+  next  
+  {% endif %}  
 end

--- a/bgp-per-overlay/optional/06-Hub-Firewall.j2
+++ b/bgp-per-overlay/optional/06-Hub-Firewall.j2
@@ -92,4 +92,23 @@ config firewall policy
     set service "PING" "BGP"
   next
   {% endif %}
+  {# Permit incoming traffic to underlay loopback, when used #}
+  {% set lo_wan = [] %}
+  {% for i in project.profiles[profile].interfaces if i.name is defined %}
+    {% if i.src_ip is defined %}
+    {{ lo_wan.append("Lo-wan"~loop.index) or "" }}
+    {% endif %}
+  {% endfor %}
+  {% if lo_wan|count %}
+  edit 7
+    set name "Underlay Loopback"
+    set srcintf "underlay"
+    set dstintf {{ lo_wan|join(' ') }}
+    set srcaddr "all"
+    set dstaddr "all"
+    set action accept
+    set schedule "always"
+    set service "ALL"
+  next  
+  {% endif %}    
 end

--- a/bgp-per-overlay/projects/!Project.comments.j2
+++ b/bgp-per-overlay/projects/!Project.comments.j2
@@ -69,6 +69,7 @@
           'name': ,
           'role': ,
           'ip': ,
+          'src_ip': ,
           'vlanid': ,
           'parent': ,
           'access': ,


### PR DESCRIPTION
Add support for an optional parameter `src_ip` in the profile interfaces, for example:

```
    'DualISP': {
      'interfaces': [
        {
          'name': 'port1',
          'role': 'wan',
          'ol_type': 'ISP1',
          'ip': 'dhcp',
          'src_ip': isp1_lo,      <<<<<
          'dia': true
        },
```

When configured, this source IP is expected to be used for all the local-out (outgoing) traffic from this interface. What concerns Jinja, this means for example, that the overlay IPSEC tunnels will be terminated on this IP (thanks to `set local-gw` in the tunnel configuration).

The implementation will create a new loopback interface called `Lo-wan<index>` (e.g. `Lo-wan1`) with this IP. 
The format is the same as for `ip` (thus including the mask, e.g. "1.2.3.4/32").

NOTE: For the correct ADVPN operation, a firewall policy is required on the Spokes, to permit incoming traffic from the WAN interfaces to the new Lo-wan<*> interface. This is a standard FOS requirement for traffic destined to the loopback interfaces.