### PR TITLE
add support for backup tunnels (IPSEC monitor feature)

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -144,15 +144,17 @@ each device interface:
 
 #### Additional parameters for WAN-facing interfaces
 
-| Parameter       | Values  | Description                                                    |    Example     |
-|:----------------|:-------:|:---------------------------------------------------------------|:--------------:|
-| ol_type         | \<str\> | Overlay to connect to over this interface*                     |     'ISP1'     |
-| ul_name         | \<str\> | Local underlay transport name _(optional)_                     |     'ISP1'     |
-| src_ip          | \<ip\>  | Source IP for all local-out traffic (incl. IPSEC) _(optional)_ |   '1.2.3.4'    |
-| outbandwidth    | \<int\> | Total egress bandwidth _(optional)_                            |     '8000'     |
-| inbandwidth     | \<int\> | Total ingress bandwidth _(optional)_                           |     '8000'     |
-| shaping_profile | \<str\> | Shaping profile to apply _(optional)_                          | 'Edge_Shaping' |
-| dia             |  true   | Interface used for Direct Internet Access _(optional)_         |                |
+| Parameter       | Values  | Description                                                             |    Example     |
+|:----------------|:-------:|:------------------------------------------------------------------------|:--------------:|
+| ol_type         | \<str\> | Overlay to connect to over this interface*                              |     'ISP1'     |
+| ul_name         | \<str\> | Local underlay transport name _(optional)_                              |     'ISP1'     |
+| src_ip          | \<ip\>  | Source IP for all local-out traffic (incl. IPSEC) _(optional)_          |   '1.2.3.4'    |
+| outbandwidth    | \<int\> | Total egress bandwidth _(optional)_                                     |     '8000'     |
+| inbandwidth     | \<int\> | Total ingress bandwidth _(optional)_                                    |     '8000'     |
+| shaping_profile | \<str\> | Shaping profile to apply _(optional)_                                   | 'Edge_Shaping' |
+| dia             |  true   | Interface used for Direct Internet Access _(optional)_                  |                |
+| backup_group    | \<int>\ | Backup group ID _(optional)_                                            |       1        |
+| backup          |  true   | Designate this interface as backup within its backup group _(optional)_ |                |
 
 \* - The overlay types referenced here must correspond to those defined in the Hub dictionary [below](#hubs)
 

--- a/Supported_Features.md
+++ b/Supported_Features.md
@@ -30,6 +30,7 @@
 - Hub-to-Hub tunnels within and between regions
 - Spoke-to-Hub connectivity options: One-to-One, Many-to-One and Full-Mesh
 - IPSEC authentication: certificate-based and PSK 
+- Redundant IPSEC tunnels ("monitor" feature)
 - Overlay stickiness
 
 ## Other features:

--- a/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
+++ b/bgp-on-loopback-multi-vrf/02-Edge-Overlay.j2
@@ -12,6 +12,7 @@
 {% for h in project.regions[region].hubs %}
 {% set hubloop = loop %}
 {% set ol_tunnels = [] %}
+{% set backup_tunnel = {} %}
 {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
   {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
   {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
@@ -52,7 +53,14 @@ config vpn ipsec phase1-interface
     set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}
     {% if i.src_ip is defined %}
     set local-gw {{ i.src_ip|ipaddr('address') }}
-    {% endif %}    
+    {% endif %}  
+    {% if i.backup_group is defined %}
+    {% if i.backup|default(false) %}
+    set monitor "{{ backup_tunnel[i.backup_group] }}"
+    {% else %}
+      {{ backup_tunnel.update({i.backup_group: ol_tun_name}) or "" }}
+    {% endif %}
+    {% endif %}
     set dpd-retrycount 3
     set dpd-retryinterval 5
     set dpd on-idle

--- a/bgp-on-loopback/02-Edge-Overlay.j2
+++ b/bgp-on-loopback/02-Edge-Overlay.j2
@@ -10,6 +10,7 @@
 {% for h in project.regions[region].hubs %}
 {% set hubloop = loop %}
 {% set ol_tunnels = [] %}
+{% set backup_tunnel = {} %}
 {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
   {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
   {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
@@ -49,6 +50,13 @@ config vpn ipsec phase1-interface
     set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}
     {% if i.src_ip is defined %}
     set local-gw {{ i.src_ip|ipaddr('address') }}
+    {% endif %}
+    {% if i.backup_group is defined %}
+    {% if i.backup|default(false) %}
+    set monitor "{{ backup_tunnel[i.backup_group] }}"
+    {% else %}
+      {{ backup_tunnel.update({i.backup_group: ol_tun_name}) or "" }}
+    {% endif %}
     {% endif %}
     set dpd-retrycount 3
     set dpd-retryinterval 5

--- a/bgp-per-overlay/02-Edge-Overlay.j2
+++ b/bgp-per-overlay/02-Edge-Overlay.j2
@@ -9,6 +9,7 @@
 
 {% for h in project.regions[region].hubs %}
 {% set hubloop = loop %}
+{% set backup_tunnel = {} %}
 {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
 config vpn ipsec phase1-interface
   edit "H{{ hubloop.index }}_{{ i.ol_type }}"
@@ -42,6 +43,13 @@ config vpn ipsec phase1-interface
     {% if i.src_ip is defined %}
     set local-gw {{ i.src_ip|ipaddr('address') }}
     {% endif %}    
+    {% if i.backup_group is defined %}
+    {% if i.backup|default(false) %}
+    set monitor "{{ backup_tunnel[i.backup_group] }}"
+    {% else %}
+      {{ backup_tunnel.update({i.backup_group: "H"~hubloop.index~"_"~i.ol_type}) or "" }}
+    {% endif %}
+    {% endif %}
     set dpd-retrycount 3
     set dpd-retryinterval 5
     set dpd on-idle


### PR DESCRIPTION
We introduce a new abstract concept: **a backup group**. 

The most general definition is as follows. A backup group contains several WAN interfaces, some of which are designated as "backup". Those designated as "backup" are backing up the rest of the group members. In practice, it means that the overlay tunnels over them will be up only when the rest of the group members (non-backup ones) are down. However, as we explain below, there are certain limitations to this general definition, imposed by the FOS capabilities.

The concept is implemented using the IPSEC "monitor" feature available in FOS, also known as "redundant VPN" (see [here](https://docs.fortinet.com/document/fortigate/7.2.6/administration-guide/432685/manual-redundant-vpn-configuration)). 

In FOS 7.2, a backup tunnel can monitor only a single "main" tunnel. Therefore, the backup group must currently include only one non-backup interface and one or more backup interfaces. The tunnels over each backup interface will monitor the tunnel over the non-backup interface within the same backup group. Note that in the future FOS releases we will be able to lift this limitation. 

Let's consider the most common example:

```j2
{% set profiles = {
    'INET_LTE': {
      'interfaces': [
        {
          'name': 'wan1',
          'role': 'wan',
          'ol_type': 'INET',
          'ip': 'dhcp',
          'backup_group': 1,
          'dia': true
        },
        {
          'name': 'wan2',
          'role': 'wan',
          'ol_type': 'LTE',
          'ip': 'dhcp',
          'backup_group': 1,
          'backup': true,
          'dia': true
        },
        {
          'name': 'internal5',
          'role': 'lan',
          'ip': lan_ip
        }
      ]
    } 
  }
%}
```

There are two optional parameters added to the device profiles on per-interface level:

- `backup_group` defines the ID of the backup group
- `backup` (true/false) defines whether an interface is designated as backup or not

In the above example, "wan1" and "wan2" belong to the same backup group, in which "wan2" is designated as backup.

Let's assume that we have a Dual-Hub region, so that this example profile is expected to generate four overlay tunnels: H1_INET, H1_LTE, H2_INET and H2_LTE. The configuration above will result in the following redundant VPN configuration:

- H1_LTE tunnel will monitor H1_INET
- H2_LTE tunnel will monitor H2_INET

As can be seen, the IPSEC "monitor" feature is applied on per-Hub basis, within the configured backup group.