### PR TITLE
dhcp relay support and other enhancements

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -161,10 +161,12 @@ each device interface:
 
 #### Additional parameters for LAN-facing interfaces
 
-| Parameter   |    Values    | Description                                          | Default |
-|:------------|:------------:|:-----------------------------------------------------|:-------:|
-| advertise   | true / false | Advertise the prefix into BGP _(optional)_           |  true   |
-| dhcp_server | true / false | Configure DHCP server on this interface _(optional)_ |  true   |
+| Parameter          |    Values    | Description                                          | Default |
+|:-------------------|:------------:|:-----------------------------------------------------|:-------:|
+| advertise          | true / false | Advertise the prefix into BGP _(optional)_           |  true   |
+| dhcp_server        | true / false | Configure DHCP server on this interface _(optional)_ |  true   |
+| dhcp_relay         | true / false | Enable DHCP relay on this interface _(optional)_     |  false  |
+| dhcp_relay_servers |   \<str\>    | List of DHCP relay servers _(optional)_              |         |
 
 
 #### Additional parameters for the Multi-VRF flavor
@@ -282,6 +284,8 @@ they are not configured explicitly):
 | create_lan_zone         | true / false | Create System Zone for LAN interfaces (with 'role' = 'lan' in the profile)                                   |       true        |
 | lan_zone                |   \<str\>    | Name of System Zone for LAN interfaces _(when create_lan_zone = true)_                                       |    'lan_zone'     |
 | create_lan_dhcp_server  | true / false | Configure DHCP Servers on LAN interfaces                                                                     |       true        |
+| dhcp_server_startip     |   \<int\>    | First IP for DHCP Server pool, seq. in the LAN subnet _(when create_lan_dhcp_server = true)_                 |         4         |
+| dhcp_server_endip       |   \<int\>    | Last IP for DHCP Server pool, seq. in the LAN subnet _(when create_lan_dhcp_server = true)_                  |        -5         |
 | cert_auth               | true / false | Certificate-based auth for IKE/IPSEC                                                                         |       true        |
 | hub_cert_template       |   \<str\>    | Certificate name on Hubs _(when cert_auth = true)_                                                           |       'Hub'       |
 | edge_cert_template      |   \<str\>    | Certificate name on Edge _(when cert_auth = true)_                                                           |      'Edge'       |

--- a/Supported_Features.md
+++ b/Supported_Features.md
@@ -16,6 +16,7 @@
 - FEX support
 - FortiLink (SD-Branch) support
 - DHCP Server for LAN clients
+- DHCP Relay for LAN clients
 - Underlay Loopback (dedicated source IP for all local-out traffic, e.g. routable public IP or provider-independent IP)
 
 ## List of supported overlay network designs:

--- a/bgp-on-loopback-multi-vrf/01-Edge-Underlay.j2
+++ b/bgp-on-loopback-multi-vrf/01-Edge-Underlay.j2
@@ -71,6 +71,14 @@ config system interface
       {% endif %}
     {% endif %}
 
+    {# DHCP Relay #}
+    {% if i.dhcp_relay|default(false) %}
+    set dhcp-relay-service enable
+    set dhcp-relay-ip {{ i.dhcp_relay_servers }}
+    {% else %}
+    set dhcp-relay-service disable
+    {% endif %}
+
     {# Other settings #}
     {% if i.role == 'wan' %}
     set role wan
@@ -227,7 +235,7 @@ end
 {% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
-  {% if i.dhcp_server|default(true) %}
+  {% if i.dhcp_server|default(true) and not i.dhcp_relay|default(false) %}
   edit {{ 10 + loop.index0 }}
     set dns-service default
     set default-gateway {{ i.ip|ipaddr('address') }}
@@ -235,8 +243,8 @@ config system dhcp server
     set interface {{ i.name }}
     config ip-range
       edit 1
-        set start-ip {{ i.ip|ipaddr(4)|ipaddr('address') }}
-        set end-ip {{ i.ip|ipaddr(-5)|ipaddr('address') }}
+        set start-ip {{ i.ip|ipaddr(project.dhcp_server_startip|default(4))|ipaddr('address') }}
+        set end-ip {{ i.ip|ipaddr(project.dhcp_server_endip|default(-5))|ipaddr('address') }}
       next
     end
   next

--- a/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
+++ b/bgp-on-loopback-multi-vrf/projects/!Project.comments.j2
@@ -26,7 +26,10 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+
 {% set create_lan_dhcp_server = true %}
+{% set dhcp_server_startip = 4 %}
+{% set dhcp_server_endip = -5 %}
 
 {% set create_vrf_leak_zone = true %}
 {% set vrf_leak_zone = 'vrfs_leak_zone' %}
@@ -94,6 +97,9 @@
           'outbandwidth': ,
           'inbandwidth': ,
           'shaping_profile': ,
+          'dhcp_server': ,
+          'dhcp_relay': ,
+          'dhcp_relay_servers': ,
           'dia': ,
           'advertise': ,
           'vrf': ,

--- a/bgp-on-loopback/01-Edge-Underlay.j2
+++ b/bgp-on-loopback/01-Edge-Underlay.j2
@@ -60,6 +60,14 @@ config system interface
       {% endif %}
     {% endif %}
 
+    {# DHCP Relay #}
+    {% if i.dhcp_relay|default(false) %}
+    set dhcp-relay-service enable
+    set dhcp-relay-ip {{ i.dhcp_relay_servers }}
+    {% else %}
+    set dhcp-relay-service disable
+    {% endif %}
+
     {# Other settings #}
     {% if i.role == 'wan' %}
     set role wan
@@ -143,7 +151,7 @@ end
 {% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
-  {% if i.dhcp_server|default(true) %}
+  {% if i.dhcp_server|default(true) and not i.dhcp_relay|default(false) %}
   edit {{ 10 + loop.index0 }}
     set dns-service default
     set default-gateway {{ i.ip|ipaddr('address') }}
@@ -151,8 +159,8 @@ config system dhcp server
     set interface {{ i.name }}
     config ip-range
       edit 1
-        set start-ip {{ i.ip|ipaddr(4)|ipaddr('address') }}
-        set end-ip {{ i.ip|ipaddr(-5)|ipaddr('address') }}
+        set start-ip {{ i.ip|ipaddr(project.dhcp_server_startip|default(4))|ipaddr('address') }}
+        set end-ip {{ i.ip|ipaddr(project.dhcp_server_endip|default(-5))|ipaddr('address') }}
       next
     end
   next

--- a/bgp-on-loopback/projects/!Project.comments.j2
+++ b/bgp-on-loopback/projects/!Project.comments.j2
@@ -26,7 +26,10 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+
 {% set create_lan_dhcp_server = true %}
+{% set dhcp_server_startip = 4 %}
+{% set dhcp_server_endip = -5 %}
 
 {% set cert_auth = true %}
 {% set hub_cert_template = 'Hub' %}
@@ -82,6 +85,9 @@
           'outbandwidth': ,
           'inbandwidth': ,
           'shaping_profile': ,
+          'dhcp_server': ,
+          'dhcp_relay': ,
+          'dhcp_relay_servers': ,
           'dia': ,
           'advertise' 
         },

--- a/bgp-per-overlay/01-Edge-Underlay.j2
+++ b/bgp-per-overlay/01-Edge-Underlay.j2
@@ -60,6 +60,14 @@ config system interface
       {% endif %}
     {% endif %}
 
+    {# DHCP Relay #}
+    {% if i.dhcp_relay|default(false) %}
+    set dhcp-relay-service enable
+    set dhcp-relay-ip {{ i.dhcp_relay_servers }}
+    {% else %}
+    set dhcp-relay-service disable
+    {% endif %}
+
     {# Other settings #}
     {% if i.role == 'wan' %}
     set role wan
@@ -143,7 +151,7 @@ end
 {% if project.create_lan_dhcp_server|default(true) %}
 config system dhcp server
   {% for i in project.profiles[profile].interfaces if i.role == 'lan' and i.name is defined %}
-  {% if i.dhcp_server|default(true) %}
+  {% if i.dhcp_server|default(true) and not i.dhcp_relay|default(false) %}
   edit {{ 10 + loop.index0 }}
     set dns-service default
     set default-gateway {{ i.ip|ipaddr('address') }}
@@ -151,8 +159,8 @@ config system dhcp server
     set interface {{ i.name }}
     config ip-range
       edit 1
-        set start-ip {{ i.ip|ipaddr(4)|ipaddr('address') }}
-        set end-ip {{ i.ip|ipaddr(-5)|ipaddr('address') }}
+        set start-ip {{ i.ip|ipaddr(project.dhcp_server_startip|default(4))|ipaddr('address') }}
+        set end-ip {{ i.ip|ipaddr(project.dhcp_server_endip|default(-5))|ipaddr('address') }}
       next
     end
   next

--- a/bgp-per-overlay/projects/!Project.comments.j2
+++ b/bgp-per-overlay/projects/!Project.comments.j2
@@ -26,7 +26,10 @@
 {% set hub2hub_zone = 'hub2hub_overlay' %}
 {% set create_lan_zone = true %}
 {% set lan_zone = 'lan_zone' %}
+
 {% set create_lan_dhcp_server = true %}
+{% set dhcp_server_startip = 4 %}
+{% set dhcp_server_endip = -5 %}
 
 {% set cert_auth = true %}
 {% set hub_cert_template = 'Hub' %}
@@ -77,6 +80,9 @@
           'outbandwidth': ,
           'inbandwidth': ,
           'shaping_profile': ,
+          'dhcp_server': ,
+          'dhcp_relay': ,
+          'dhcp_relay_servers': ,
           'dia': ,
           'advertise' 
         },


### PR DESCRIPTION
The following functionality is added:

1. DHCP Relay support per interface:

   ```
   {% set profiles = {
       'MyProfile': {
         'interfaces': [
           {
             'name': 'port1',
             'role': 'lan',
             'dhcp_relay': true,
             'dhcp_relay_servers': "10.1.1.1 10.2.2.2 10.3.3.3",
             #...
           },
   ```

2. Customization of the IP range used by the local DHCP server on LAN interfaces (optional Project-wide variable):

   ```
   {% set dhcp_server_startip = 4 %}
   {% set dhcp_server_endip = -5 %}
   ```

   The default values are as above (start-ip = 4th IP of the subnet, end-ip = 5th IP from the end of the subnet)

The ways to control local DHCP Server / DHCP Relay:

- This global Project-wide variable enables/disables DHCP Server creation on all LAN interfaces (enabled by default):

   ```
   {% set create_lan_dhcp_server = true %}
   ```

- If the global switch is "true", you can still avoid configuration of the DHCP Server per interface, adding `dhcp_server: false`:

   ```
   {% set profiles = {
       'MyProfile': {
         'interfaces': [
           {
             'name': 'port1',
             'role': 'lan',
             'dhcp_server': false
             #...
           },
   ```

- If DHCP relay is enabled on the interface, the local DHCP Server will NOT be configured (same as adding `dhcp_server: false`)