### PR TITLE
hardware switch support

### DIFF
--- a/Project_Template_Reference.md
+++ b/Project_Template_Reference.md
@@ -67,13 +67,24 @@ The following table lists all the parameters that must be configured for each re
 
 The `profiles` dictionary describes all the device profiles in the project.
 By device profiles we mainly mean the list of interfaces for each site,
-with the respective options for each interface. Thus, the profile describes the
-local topology and the connectivity options for each site:
+with the respective options for each interface. Optionally, there can also be a list of 
+bridges - the hardware switches built into certain FortiGate models, also known as "virtual-switches". 
+Thus, the profile describes the local topology and the connectivity options for each site:
 
 ```
 {# Device Profiles #}
 {% set profiles = {
     'Profile1': {
+      'bridges': [
+        {# Optional: virtual-switch (build-in hardware switch) parameters #}
+        {
+          {# Virtual-switch1 parameters #}
+        },
+        {
+          {# Virtual-switch2 parameters #}
+        }
+        {# ... #}
+      ],
       'interfaces': [
         {
           {# Interface1 parameters #}
@@ -102,7 +113,7 @@ local topology and the connectivity options for each site:
 
 NOTE: All the Edge devices and the Hubs must be assigned a profile!
 
-Apart from the list of interfaces, the profile can also specify that a device is in HA cluster mode:
+Apart from the lists of bridges and interfaces, the profile can also specify that a device is in HA cluster mode:
 
 | Parameter | Values | Description                           | Example |
 |:----------|:------:|:--------------------------------------|:-------:|
@@ -127,20 +138,38 @@ Example:
 
 Each deployed SD-WAN site will be assigned a profile.
 
+The following table lists all the supported parameters that can be configured for 
+each bridge (remember that the list of bridges is optional):
+
+| Parameter | Values  | Description                                                             | Example  |
+|:----------|:-------:|:------------------------------------------------------------------------|:--------:|
+| name      | \<str\> | Bridge (virtual-switch) name                                            | 'BR_LAN' |
+| vlanid    | \<int\> | VLAN ID (automatically enables virtual-switch-vlan feature) _optional_) |   '10'   |
+
+NOTE: It is the user's responsibility to ensure that the FortiGate devices being used support hardware switches 
+and/or virtual-switch-vlan functionality. No hardware model check is performed.
+
 The following tables lists all the supported parameters that can be configured for
 each device interface:
 
 #### Parameters for all interfaces
 
-| Parameter |           Values            | Description                                                        |        Example         |
-|:----------|:---------------------------:|:-------------------------------------------------------------------|:----------------------:|
-| name      |           \<str\>           | Interface name                                                     |        'port1'         |
-| role      | 'wan' / 'lan' / 'sd_branch' | Interface role (respectively: WAN-facing / LAN-facing / Fortilink) |                        |
-| ip        |    \<ip/mask\> / 'dhcp'     | Interface IP address (with mask) / Enable DHCP client              | '10.0.1.1/24' / 'dhcp' |
-| vlanid    |           \<int\>           | VLAN ID (for VLAN interfaces, _optional_)                          |          '10'          |
-| parent    |           \<str\>           | Parent interface (for VLAN interfaces, _when vlan_id is set_)      |        'port1'         |
-| access    |           \<str\>           | Custom list of services to allow access (such as FGFM, _optional_) |   'ping fgfm https'    |
+| Parameter |        Values        | Description                                                        |        Example         |
+|:----------|:--------------------:|:-------------------------------------------------------------------|:----------------------:|
+| name      |       \<str\>        | Interface name                                                     |        'port1'         |
+| role      |       \<role\>       | Interface role*                                                    |                        |
+| ip        | \<ip/mask\> / 'dhcp' | Interface IP address (with mask) / Enable DHCP client              | '10.0.1.1/24' / 'dhcp' |
+| vlanid    |       \<int\>        | VLAN ID (for VLAN interfaces, _optional_)                          |          '10'          |
+| parent    |       \<str\>        | Parent interface (for VLAN and bridge interfaces)                  |        'port1'         |
+| access    |       \<str\>        | Custom list of services to allow access (such as FGFM, _optional_) |   'ping fgfm https'    |
 
+\* - The following interface roles are supported:
+
+  - `wan`: a WAN-facing Layer3 interface (incl. physical, VLAN, IRB...)
+  - `lan`: a LAN-facing Layer3 interface (incl. physical, VLAN, IRB...)
+  - `sd_branch`: a Fortilink member (usually connected to a FortiSwitch)
+  - `bridge`: a virtual-switch (built-in hardware switch) member
+  - `trunk`: 802.1Q trunk (for virtual-vlan-switch feature)
 
 #### Additional parameters for WAN-facing interfaces
 

--- a/Supported_Features.md
+++ b/Supported_Features.md
@@ -13,6 +13,7 @@
 
 - DHCP and static IP
 - VLAN tagging
+- Bridging (built-in hardware switches, incl. virtual-switch-vlan support)
 - FEX support
 - FortiLink (SD-Branch) support
 - DHCP Server for LAN clients

--- a/bgp-on-loopback-multi-vrf/01-Edge-Underlay.j2
+++ b/bgp-on-loopback-multi-vrf/01-Edge-Underlay.j2
@@ -21,6 +21,30 @@ config system global
   {% endif %}
 end
 
+{# Create hardware switches #}
+{% set vlan_switch = project.profiles[profile].bridges|default({})|selectattr('vlanid', 'defined')|list %}
+{% if project.profiles[profile].bridges is defined %}
+config system global
+  set virtual-switch-vlan {{ 'enable' if vlan_switch else 'disable' }}
+end
+{% for br in project.profiles[profile].bridges if br.name is defined %}
+config system virtual-switch
+  edit "{{br.name}}"
+    set physical-switch "sw0"
+    {% if br.vlanid is defined %}
+    set vlan {{br.vlanid}}
+    {% endif %}
+    config port
+      {% for i in project.profiles[profile].interfaces if i.role == 'bridge' and i.parent == br.name and i.name is defined %}
+      edit "{{i.name}}"
+      next
+      {% endfor %}
+    end
+  next
+end
+{% endfor %}
+{% endif %}
+
 {# Loop: Configure underlay interfaces #}
 {% for i in project.profiles[profile].interfaces if i.name is defined %}
 config system interface
@@ -72,22 +96,25 @@ config system interface
     {% endif %}
 
     {# DHCP Relay #}
-    {% if i.dhcp_relay|default(false) %}
+    {% if i.role == 'lan' and i.dhcp_relay|default(false) %}
     set dhcp-relay-service enable
     set dhcp-relay-ip {{ i.dhcp_relay_servers }}
-    {% else %}
+    {% elif i.role == 'lan' %}
     set dhcp-relay-service disable
     {% endif %}
 
     {# Other settings #}
     {% if i.role == 'wan' %}
     set role wan
-    {% endif %}
-    {% if i.role == 'lan' %}
+    {% elif i.role == 'lan' %}
     set role lan
     set device-identification enable
+    {% elif i.role == 'trunk' %}
+    set trunk {{ 'enable' if vlan_switch else 'disable' }}
     {% endif %}
+    {% if i.ip is defined %}
     set allowaccess {{ 'ping' if not i.access|default(false) else i.access }}
+    {% endif %}
   next
 end
 

--- a/bgp-on-loopback/01-Edge-Underlay.j2
+++ b/bgp-on-loopback/01-Edge-Underlay.j2
@@ -17,6 +17,30 @@ config system global
   {% endif %}
 end
 
+{# Create hardware switches #}
+{% if project.profiles[profile].bridges is defined %}
+{% set vlan_switch = project.profiles[profile].bridges|selectattr('vlanid', 'defined')|list %}
+config system global
+  set virtual-switch-vlan {{ 'enable' if vlan_switch else 'disable' }}
+end
+{% for br in project.profiles[profile].bridges if br.name is defined %}
+config system virtual-switch
+  edit "{{br.name}}"
+    set physical-switch "sw0"
+    {% if br.vlanid is defined %}
+    set vlan {{br.vlanid}}
+    {% endif %}
+    config port
+      {% for i in project.profiles[profile].interfaces if i.role == 'bridge' and i.parent == br.name and i.name is defined %}
+      edit "{{i.name}}"
+      next
+      {% endfor %}
+    end
+  next
+end
+{% endfor %}
+{% endif %}
+
 {# Loop: Configure underlay interfaces #}
 {% for i in project.profiles[profile].interfaces if i.name is defined %}
 config system interface
@@ -61,22 +85,25 @@ config system interface
     {% endif %}
 
     {# DHCP Relay #}
-    {% if i.dhcp_relay|default(false) %}
+    {% if i.role == 'lan' and i.dhcp_relay|default(false) %}
     set dhcp-relay-service enable
     set dhcp-relay-ip {{ i.dhcp_relay_servers }}
-    {% else %}
+    {% elif i.role == 'lan' %}
     set dhcp-relay-service disable
     {% endif %}
 
     {# Other settings #}
     {% if i.role == 'wan' %}
     set role wan
-    {% endif %}
-    {% if i.role == 'lan' %}
+    {% elif i.role == 'lan' %}
     set role lan
     set device-identification enable
+    {% elif i.role == 'trunk' %}
+    set trunk enable
     {% endif %}
+    {% if i.ip is defined %}
     set allowaccess {{ 'ping' if not i.access|default(false) else i.access }}
+    {% endif %}
   next
 end
 

--- a/bgp-on-loopback/01-Edge-Underlay.j2
+++ b/bgp-on-loopback/01-Edge-Underlay.j2
@@ -18,8 +18,8 @@ config system global
 end
 
 {# Create hardware switches #}
+{% set vlan_switch = project.profiles[profile].bridges|default({})|selectattr('vlanid', 'defined')|list %}
 {% if project.profiles[profile].bridges is defined %}
-{% set vlan_switch = project.profiles[profile].bridges|selectattr('vlanid', 'defined')|list %}
 config system global
   set virtual-switch-vlan {{ 'enable' if vlan_switch else 'disable' }}
 end
@@ -99,7 +99,7 @@ config system interface
     set role lan
     set device-identification enable
     {% elif i.role == 'trunk' %}
-    set trunk enable
+    set trunk {{ 'enable' if vlan_switch else 'disable' }}
     {% endif %}
     {% if i.ip is defined %}
     set allowaccess {{ 'ping' if not i.access|default(false) else i.access }}

--- a/bgp-per-overlay/01-Edge-Underlay.j2
+++ b/bgp-per-overlay/01-Edge-Underlay.j2
@@ -17,6 +17,30 @@ config system global
   {% endif %}
 end
 
+{# Create hardware switches #}
+{% set vlan_switch = project.profiles[profile].bridges|default({})|selectattr('vlanid', 'defined')|list %}
+{% if project.profiles[profile].bridges is defined %}
+config system global
+  set virtual-switch-vlan {{ 'enable' if vlan_switch else 'disable' }}
+end
+{% for br in project.profiles[profile].bridges if br.name is defined %}
+config system virtual-switch
+  edit "{{br.name}}"
+    set physical-switch "sw0"
+    {% if br.vlanid is defined %}
+    set vlan {{br.vlanid}}
+    {% endif %}
+    config port
+      {% for i in project.profiles[profile].interfaces if i.role == 'bridge' and i.parent == br.name and i.name is defined %}
+      edit "{{i.name}}"
+      next
+      {% endfor %}
+    end
+  next
+end
+{% endfor %}
+{% endif %}
+
 {# Loop: Configure underlay interfaces #}
 {% for i in project.profiles[profile].interfaces if i.name is defined %}
 config system interface
@@ -61,22 +85,25 @@ config system interface
     {% endif %}
 
     {# DHCP Relay #}
-    {% if i.dhcp_relay|default(false) %}
+    {% if i.role == 'lan' and i.dhcp_relay|default(false) %}
     set dhcp-relay-service enable
     set dhcp-relay-ip {{ i.dhcp_relay_servers }}
-    {% else %}
+    {% elif i.role == 'lan' %}
     set dhcp-relay-service disable
     {% endif %}
 
     {# Other settings #}
     {% if i.role == 'wan' %}
     set role wan
-    {% endif %}
-    {% if i.role == 'lan' %}
+    {% elif i.role == 'lan' %}
     set role lan
     set device-identification enable
+    {% elif i.role == 'trunk' %}
+    set trunk {{ 'enable' if vlan_switch else 'disable' }}
     {% endif %}
+    {% if i.ip is defined %}
     set allowaccess {{ 'ping' if not i.access|default(false) else i.access }}
+    {% endif %}
   next
 end
 


### PR DESCRIPTION
Support hardware switch built into some FortiGate models. Also virtual VLAN switch is supported. 

> Note that we do not validate hardware support in any way. Therefore, it is the responsibility of the user to configure these features only when they are supported by the FortiGate devices in use.

Below is a complete configuration example of a hardware switch in the device profile:

```
{# Device Profiles #}
{% set profiles = {
    'MyBranch': {
      'bridges': [
        {
          'name': 'BR_LAN', 
          'vlanid': 10
        }
      ],
      'interfaces': [
        # ...
        {
          'name': 'BR_LAN',
          'role': 'lan',
          'ip': lan_ip
        },
        {
          'name': 'internal5',
          'role': 'bridge',
          'parent': 'BR_LAN'
        },
        {
          'name': 'internal6',
          'role': 'bridge',
          'parent': 'BR_LAN'
        },
        {
          'name': 'internal7',
          'role': 'trunk'
        }
      ]
    }     

  }
%}
```

There are four different configuration elements here:

- First, the hardware switch is defined under the `bridges` list. The `vlanid` parameter is optional. If it is set, then the "virtual-vlan-switch" function is automatically enabled. 

- Physical ports are added to the hardware switch in the `interfaces` list, by setting `'role': 'bridge'` and specifying the name of the hardware switch in the `parent` parameter. 

- Physical ports can be configured as trunks (only valid when virtual-vlan-switch function is used), by setting `'role': 'trunk'`.

- Finally, the L3 interface of the switch can be configured as any other L3 interface, in the `interfaces` list. In the above example, that's a LAN-facing interface. Its name must be identical to the hardware switch name ("BR_LAN" in our example).