### PR TITLE
Enhance Dynamic BGP support with remote-as-filter (7.4.5+) and allow Spoke-to-Hub shortcuts

### DIFF
--- a/dynamic-bgp-on-lo/03-Edge-Routing.j2
+++ b/dynamic-bgp-on-lo/03-Edge-Routing.j2
@@ -138,8 +138,7 @@ config router bgp
   {% endif %}
   {% if options.dynamic_bgp %}
   config neighbor-group
-    {# START: Awaiting FOS bugfix for remote-as-filter feature #}
-    {# edit "DYN_EDGE"
+    edit "DYN_EDGE"
       set ebgp-enforce-multihop enable 
       set soft-reconfiguration enable
       set capability-graceful-restart enable
@@ -158,43 +157,13 @@ config router bgp
       unset soft-reconfiguration-vpnv4
       unset capability-graceful-restart-vpnv4
       {% endif %}
-    next #}
-    {# END: Awaiting FOS bugfix for remote-as-filter feature #}
-    {% for r in project.regions %}
-    edit "DYN_EDGE_{{r}}"
-      set ebgp-enforce-multihop enable 
-      set soft-reconfiguration enable
-      set capability-graceful-restart enable
-      set advertisement-interval 1
-      set next-hop-self enable
-      set remote-as {{ project.regions[r].as }}
-      set interface "Lo"
-      set update-source "Lo"
-      set passive disable
-      set route-map-out{{'-vpnv4' if multi_vrf}} "LAN_OUT"
-      {% if multi_vrf %}
-      set soft-reconfiguration-vpnv4 enable
-      set capability-graceful-restart-vpnv4 enable      
-      {% else %}
-      unset soft-reconfiguration-vpnv4
-      unset capability-graceful-restart-vpnv4
-      {% endif %}
     next
-    {% endfor %}
   end
   config neighbor-range
-    {# START: Awaiting FOS bugfix for remote-as-filter feature #}
-    {# edit 101
+    edit 101
       set prefix {{ project.lo_summary }}
       set neighbor-group "DYN_EDGE"
-    next #}
-    {# END: Awaiting FOS bugfix for remote-as-filter feature #}
-    {% for r in project.regions %}
-    edit {{ 100 + loop.index }}
-      set prefix {{ project.regions[r].lo_summary }}
-      set neighbor-group "DYN_EDGE_{{r}}"
     next
-    {% endfor %}
   end  
   {% endif %}
 

--- a/dynamic-bgp-on-lo/03-Hub-Routing.j2
+++ b/dynamic-bgp-on-lo/03-Hub-Routing.j2
@@ -16,7 +16,7 @@
         {
           'EDGE': {
             'dynamic_bgp': project.dynamic_bgp|default(false),
-            'lo_summary': project.lo_summary
+            'lo_summary': project.regions[region].lo_summary|default(project.lo_summary)
           }
         }
     )

--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -15,7 +15,8 @@
 
 {# Options: project-wide defaults #}
 {% set options = {
-    'force_cleanup': project.force_cleanup|default(false)
+    'force_cleanup': project.force_cleanup|default(false),
+    'spoke2hub_advpn': project.spoke2hub_advpn|default(false)
   }
 %}
 {# Options can be selectively overriden in profile #}
@@ -115,6 +116,21 @@ end
 
 {# Build Hub-to-Hub BGP peering #}
 
+config router aspath-list
+  edit "SDWAN_AS"
+    config rule
+      purge
+      {# List ASNs of all defined regions, except for ours #}
+      {% for r in project.regions if r != region %}
+      edit {{ loop.index }}
+        set action permit
+        set regexp "{{ project.regions[r].as }}"
+      next
+      {% endfor %}
+    end
+  next
+end
+
 config router access-list
   {# Advertise regional LAN summaries between the regions #}
   edit "LAN_REGIONAL_SUMMARY"
@@ -156,7 +172,7 @@ config router bgp
 end
 
 config router route-map
-  edit "HUB2HUB_OUT"
+  edit "REGION_OUT"
     config rule
       purge
       edit 1
@@ -190,7 +206,7 @@ config router bgp
       set connect-timer 1
       set remote-as {{ project.regions[r].as }}
       unset route-map-out{{'-vpnv4' if not multi_vrf}}
-      set route-map-out{{'-vpnv4' if multi_vrf}} "HUB2HUB_OUT"      
+      set route-map-out{{'-vpnv4' if multi_vrf}} "REGION_OUT"      
       {% if multi_vrf %}
       set soft-reconfiguration-vpnv4 enable
       set capability-graceful-restart-vpnv4 enable
@@ -202,6 +218,35 @@ config router bgp
     {% endfor %}
     {% endfor %}
   end
+  {% if options.spoke2hub_advpn %}
+  config neighbor-group
+    edit "DYN_EDGE"
+      set ebgp-enforce-multihop enable 
+      set soft-reconfiguration enable
+      set capability-graceful-restart enable
+      set advertisement-interval 1
+      set remote-as-filter "SDWAN_AS"
+      set interface "Lo"
+      set update-source "Lo"
+      set passive disable
+      unset route-map-out{{'-vpnv4' if not multi_vrf}}
+      set route-map-out{{'-vpnv4' if multi_vrf}} "REGION_OUT"
+      {% if multi_vrf %}
+      set soft-reconfiguration-vpnv4 enable
+      set capability-graceful-restart-vpnv4 enable      
+      {% else %}
+      unset soft-reconfiguration-vpnv4
+      unset capability-graceful-restart-vpnv4
+      {% endif %}
+    next
+  end
+  config neighbor-range
+    edit {{ 101 + project.hubs[hostname].peering|default([1])|length }}
+      set prefix {{ project.lo_summary }}
+      set neighbor-group "DYN_EDGE"
+    next
+  end
+  {% endif %}   
 end
 
 {# End: multi-regional config #}


### PR DESCRIPTION
This PR introduces the following changes:

- Use `remote-as-filter` to generate a unified neighbor-group DYN_EDGE on the Spokes, ready to accept dynamic BGP sessions from all the regions (IBGP and EBGP). This replaces the earlier method (generating a separate neighbor-group per region on all Spokes)

- Add a new optional variable `spoke2hub_advpn` (global or per-profile) to support Spoke-to-Hub shortcuts in multiregional deployments. When enabled, we will generate the neighbor-group DYN_EDGE also on the Hubs (using the `remote-as-filter` as well), to accept dynamic EBGP sessions from remote Spokes. We will advertise the regional LAN summary, as well as Hub's LAN over this session. 

- The route-map-out used on external peering in the multiregional deployment is renamed from "HUB2HUB_OUT" to "REGION_OUT", and it is now applied not only to the Hub-to-Hub peering, but also to the new DYN_EDGE peering on the Hubs (for the Spoke-to-Hub shortcuts).

- When generating the neighbor-range on the Hubs (for the local IBGP sessions), we now prefer to use the local regional summary (if configured), rather than the global lo_summary. If the regional lo_summary is not configured (in a single-regional deployment), we will keep using the global lo_summary as before.