### PR TITLE
Add optional Hub label for tunnel naming

### DIFF
--- a/dynamic-bgp-on-lo/02-Edge-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Edge-Overlay.j2
@@ -17,9 +17,11 @@
 {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
   {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
   {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
-  {% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
+  {# If no explicit Hub name is defined, then "H<hub_number>" is used #}
+  {% set hub_name = project.hubs[h].hub_name|upper if project.hubs[h].hub_name is defined else "H"~hubloop.index %}
+  {% set ol_tun = ul_name~hub_name~"_"~i.ol_type %}
   {% set count = ol_tunnels|select("equalto", ol_tun)|list|count %}
-  {# Tunnel name = 'H<hub_number>_<ol_type>' if no duplicates, otherwise 'H<hub_number>_<ol_type>_<index>' #}
+  {# Tunnel name = '<hub_name>_<ol_type>' if no duplicates, otherwise '<hub_name>_<ol_type>_<index>' #}
   {% set ol_tun_name = ol_tun if not count else ol_tun~'_'~(count+1) %}
   {{ ol_tunnels.append(ol_tun) or "" }}
 config vpn ipsec phase1-interface

--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -38,8 +38,11 @@
     {% for h in project.regions[r].hubs %}
       {% if i.ol_type in project.hubs[h].overlays and 
             project.hubs[h].overlays[i.ol_type].hub2hub|default(true) %}
+      {# If no explicit Hub name is defined, then "H<hub_number>" is used #}
+      {% set hub_name = project.hubs[h].hub_name|upper if project.hubs[h].hub_name is defined else "H"~loop.index %}
+      {% set ol_tun_name = r|upper~"_"~hub_name~"_"~i.ol_type %}            
       config vpn ipsec phase1-interface
-        edit "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+        edit "{{ ol_tun_name }}"
           set interface "{{ i.name }}"
           set ike-version 2
           {% if project.cert_auth|default(true) %}
@@ -74,15 +77,15 @@
         next
       end
       config vpn ipsec phase2-interface
-        edit "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
-          set phase1name "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+        edit "{{ ol_tun_name }}"
+          set phase1name "{{ ol_tun_name }}"
           set proposal aes256gcm
           set keepalive enable
           set keylifeseconds 3600
         next
       end
       config system interface
-        edit "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+        edit "{{ ol_tun_name }}"
           set vrf {{ pe_vrf }} 
         next
       end
@@ -90,17 +93,17 @@
       config router policy
         edit {{ hub2hub_ol|length * 2 + 11 }}
           set input-device "EDGE_{{ i.ol_type }}"
-          set output-device "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+          set output-device "{{ ol_tun_name }}"
           {{'un' if not project.lan_summary|default()}}set dst {{ project.lan_summary|default() }}
         next
         edit {{ hub2hub_ol|length * 2 + 12 }}
-          set input-device "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+          set input-device "{{ ol_tun_name }}"
           set output-device "EDGE_{{ i.ol_type }}"
           {{'un' if not project.lan_summary|default()}}set dst {{ project.lan_summary|default() }}
         next
       end
       {% endif %}
-      {{ hub2hub_ol.append(r|upper~'_H'~loop.index~'_'~i.ol_type) or "" }}
+      {{ hub2hub_ol.append(ol_tun_name) or "" }}
       {% endif %}
     {% endfor %}
   {% endfor %}

--- a/dynamic-bgp-on-lo/optional/11-Edge-SDWAN.j2
+++ b/dynamic-bgp-on-lo/optional/11-Edge-SDWAN.j2
@@ -63,9 +63,11 @@ config system sdwan
   {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
     {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
     {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
-    {% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
+    {# If no explicit Hub name is defined, then "H<hub_number>" is used #}
+    {% set hub_name = project.hubs[h].hub_name|upper if project.hubs[h].hub_name is defined else "H"~hubloop.index %}
+    {% set ol_tun = ul_name~hub_name~"_"~i.ol_type %}
     {% set count = ol_tunnels|select("equalto", ol_tun)|list|count %}
-    {# Tunnel name = 'H<hub_number>_<ol_type>' if no duplicates, otherwise 'H<hub_number>_<ol_type>_<index>' #}
+    {# Tunnel name = '<hub_name>_<ol_type>' if no duplicates, otherwise '<hub_name>_<ol_type>_<index>' #}
     {% set ol_tun_name = ol_tun if not count else ol_tun~'_'~(count+1) %}
     {{ ol_tunnels.append(ol_tun) or "" }}
     edit {{ ns.mbr_i }}


### PR DESCRIPTION
The default naming convention for the tunnels generated on the Spokes is: 

```
H<hub_index>_<ol_type>
```

For example, for a Dual-Hub topology we will generate tunnels like `H1_INET` and `H2_INET`. 

To simplify operations, we introduce an option to set a more meaningful label for each Hub, using an optional `hub_name` parameter in the `hubs` structure:

``` j2
{# Hubs #}
{% set hubs = {

    'site1-H1': {
      'lo_bgp': '10.200.1.253',
      'hub_name': 'TRN',          <<<<<<
      'overlays': {
         ...
```

If this option is defined, the naming convention will be:

```
<hub_name>_<ol_type>
```

In other words: `TRN_INET`.

Similarly, this optional name will be used for the Hub-to-Hub tunnels in a multi-regional deployment (e.g. `EAST_TRN_INET`).