### PR TITLE
Support multi-regional deployment without LAN summaries

### DIFF
--- a/dynamic-bgp-on-lo/02-Edge-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Edge-Overlay.j2
@@ -17,9 +17,11 @@
 {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
   {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
   {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
-  {% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
+  {# If no explicit Hub name is defined, then "H<hub_number>" is used #}
+  {% set hub_name = project.hubs[h].hub_name|upper if project.hubs[h].hub_name is defined else "H"~hubloop.index %}
+  {% set ol_tun = ul_name~hub_name~"_"~i.ol_type %}
   {% set count = ol_tunnels|select("equalto", ol_tun)|list|count %}
-  {# Tunnel name = 'H<hub_number>_<ol_type>' if no duplicates, otherwise 'H<hub_number>_<ol_type>_<index>' #}
+  {# Tunnel name = '<hub_name>_<ol_type>' if no duplicates, otherwise '<hub_name>_<ol_type>_<index>' #}
   {% set ol_tun_name = ol_tun if not count else ol_tun~'_'~(count+1) %}
   {{ ol_tunnels.append(ol_tun) or "" }}
 config vpn ipsec phase1-interface

--- a/dynamic-bgp-on-lo/03-Hub-Routing.j2
+++ b/dynamic-bgp-on-lo/03-Hub-Routing.j2
@@ -56,6 +56,7 @@ config router route-map
       edit 1
         {# Do not advertise to EBGP peers (outside the region #}
         set set-community "no-export"
+        set set-tag 100
       next
     end
   next
@@ -65,7 +66,14 @@ config router route-map
         set set-tag 100
       next
     end
-  next  
+  next 
+  edit "EDGE_OUT"
+    config rule
+      edit 100
+      {# Placeholder for advertisement filtering towards Spokes for RR-less design (default: permit all) #}
+      next
+    end
+  next 
 end
 
 config router bgp
@@ -109,6 +117,8 @@ config router bgp
       set route-reflector-client{{'-vpnv4' if multi_vrf}} enable
       {% else %}
       set route-reflector-client{{'-vpnv4' if multi_vrf}} disable
+      unset route-map-out{{'-vpnv4' if not multi_vrf}}
+      set route-map-out{{'-vpnv4' if multi_vrf}} "EDGE_OUT"          
       {% endif %}
       {% if multi_vrf %}
       set soft-reconfiguration-vpnv4 enable

--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -38,8 +38,11 @@
     {% for h in project.regions[r].hubs %}
       {% if i.ol_type in project.hubs[h].overlays and 
             project.hubs[h].overlays[i.ol_type].hub2hub|default(true) %}
+      {# If no explicit Hub name is defined, then "H<hub_number>" is used #}
+      {% set hub_name = project.hubs[h].hub_name|upper if project.hubs[h].hub_name is defined else "H"~loop.index %}
+      {% set ol_tun_name = r|upper~"_"~hub_name~"_"~i.ol_type %}            
       config vpn ipsec phase1-interface
-        edit "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+        edit "{{ ol_tun_name }}"
           set interface "{{ i.name }}"
           set ike-version 2
           {% if project.cert_auth|default(true) %}
@@ -74,15 +77,15 @@
         next
       end
       config vpn ipsec phase2-interface
-        edit "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
-          set phase1name "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+        edit "{{ ol_tun_name }}"
+          set phase1name "{{ ol_tun_name }}"
           set proposal aes256gcm
           set keepalive enable
           set keylifeseconds 3600
         next
       end
       config system interface
-        edit "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+        edit "{{ ol_tun_name }}"
           set vrf {{ pe_vrf }} 
         next
       end
@@ -90,17 +93,17 @@
       config router policy
         edit {{ hub2hub_ol|length * 2 + 11 }}
           set input-device "EDGE_{{ i.ol_type }}"
-          set output-device "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+          set output-device "{{ ol_tun_name }}"
           {{'un' if not project.lan_summary|default()}}set dst {{ project.lan_summary|default() }}
         next
         edit {{ hub2hub_ol|length * 2 + 12 }}
-          set input-device "{{ r|upper }}_H{{ loop.index}}_{{ i.ol_type }}"
+          set input-device "{{ ol_tun_name }}"
           set output-device "EDGE_{{ i.ol_type }}"
           {{'un' if not project.lan_summary|default()}}set dst {{ project.lan_summary|default() }}
         next
       end
       {% endif %}
-      {{ hub2hub_ol.append(r|upper~'_H'~loop.index~'_'~i.ol_type) or "" }}
+      {{ hub2hub_ol.append(ol_tun_name) or "" }}
       {% endif %}
     {% endfor %}
   {% endfor %}

--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -119,6 +119,8 @@ end
 
 {# Build Hub-to-Hub BGP peering #}
 
+{% set ns = namespace(summarize = false) %}
+
 config router aspath-list
   edit "SDWAN_AS"
     config rule
@@ -140,11 +142,13 @@ config router access-list
     config rule
       purge
       {% for v in project.regions[region].vrfs|default(
-                  [{ 'lan_summary': project.regions[region].lan_summary }]) %}
+                  [{ 'lan_summary': project.regions[region].lan_summary }]) 
+                  if v.lan_summary is defined %}
       edit 0
         set prefix {{ v.lan_summary }}
         set exact-match enable
       next
+      {% set ns.summarize = true %}
       {% endfor %}      
     end
   next
@@ -183,17 +187,27 @@ config router route-map
         set match-tag 100
       next
       edit 2
-        set match-ip-address "LAN_REGIONAL_SUMMARY"
-        set set-metric {{ 100 if my_index == 2 else 0 }}
+        set match-ip-address "LO_REGIONAL_SUMMARY"
+        set set-metric {{ 100 if my_index == 2 else 50 }}
       next
       edit 3
-        {# Do not readvertise regional loopback summary to remote Edges and other regions #}
-        set match-ip-address "LO_REGIONAL_SUMMARY"
-        set set-community no-advertise
-        set set-metric {{ 100 if my_index == 2 else 0 }}
+        {% if ns.summarize %}
+        set match-ip-address "LAN_REGIONAL_SUMMARY"
+        {% endif %}
+        set set-metric {{ 100 if my_index == 2 else 50 }}
       next
     end
   next
+  edit "EDGE_OUT"
+    config rule
+      edit 100
+        unset match-tag
+        {% if not ns.summarize %}
+        set match-tag 100
+        {% endif %}
+      next
+    end
+  next    
 end
 config router bgp
   config neighbor
@@ -209,7 +223,7 @@ config router bgp
       set connect-timer 1
       set remote-as {{ project.regions[r].as }}
       unset route-map-out{{'-vpnv4' if not multi_vrf}}
-      set route-map-out{{'-vpnv4' if multi_vrf}} "REGION_OUT"      
+      set route-map-out{{'-vpnv4' if multi_vrf}} "REGION_OUT"
       {% if multi_vrf %}
       set soft-reconfiguration-vpnv4 enable
       set capability-graceful-restart-vpnv4 enable

--- a/dynamic-bgp-on-lo/optional/11-Edge-SDWAN.j2
+++ b/dynamic-bgp-on-lo/optional/11-Edge-SDWAN.j2
@@ -63,9 +63,11 @@ config system sdwan
   {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
     {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
     {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
-    {% set ol_tun = ul_name~"H"~hubloop.index~"_"~i.ol_type %}
+    {# If no explicit Hub name is defined, then "H<hub_number>" is used #}
+    {% set hub_name = project.hubs[h].hub_name|upper if project.hubs[h].hub_name is defined else "H"~hubloop.index %}
+    {% set ol_tun = ul_name~hub_name~"_"~i.ol_type %}
     {% set count = ol_tunnels|select("equalto", ol_tun)|list|count %}
-    {# Tunnel name = 'H<hub_number>_<ol_type>' if no duplicates, otherwise 'H<hub_number>_<ol_type>_<index>' #}
+    {# Tunnel name = '<hub_name>_<ol_type>' if no duplicates, otherwise '<hub_name>_<ol_type>_<index>' #}
     {% set ol_tun_name = ol_tun if not count else ol_tun~'_'~(count+1) %}
     {{ ol_tunnels.append(ol_tun) or "" }}
     edit {{ ns.mbr_i }}


### PR DESCRIPTION
Normally we expect the LAN prefixes to be summaried on the regional boundaries (that is, on the Hub-to-Hub EBGP peering). However, this is not always possible: network addressing is not always under customer's tight control. 

This enhancement makes the LAN summarization **optional**. 

In fact, it was already optional within the region. Now it becomes optional also for a multi-regional deployment. 
Below we summarize the routing behavior.

- Within a region:

  - If the LAN summary is configured: 
    - It is automatically advertised to all the Spokes. 
    - In a multi-VRF deployment, this advertisement is done for each CE VRF. 

  - If the LAN summary is not configured:
    - The user must make sure that the Spokes have a valid route to all the LAN destinations via the overlay tunnels. 
    - In a single-VRF deployment, this can be achieved simply by adding a static default route via the entire SD-WAN zone.   
      In the offline mode, this is automatically done by the Jinja Orchestrator.   
      In FortiManager-based deployment, this must be done externally.  
    - In a multi-VRF deployment, such a default route must be added to each CE VRF, which becomes a burden.  
      The Jinja Orchestrator does not handle this.

- Between regions:

  - If the LAN summary is configured:
    - It is automatically advertised over the Hub-to-Hub tunnels, aggregating the individual Spoke prefixes.
    - In a multi-VRF deployment, this advertisement is done for each CE VRF.
  
  - If the LAN summary is not configured:
    - All individual Spoke prefixes are advertised over the Hub-to-Hub tunnels, to guarantee inter-regional reachability.
    - These advertisements are not sent down to the Spokes of the remote region.  
      The expectation is, again, that Spokes have a valid route (e.g. default route) to all the LAN destinations via the overlay tunnels. 

The bottom line is: we recommend configuring LAN summaries whenever the network addressing permits that, to guarantee the most scalable routing design. At the same time, we support network environments where this summarization is not possible. 