### PR TITLE
Support Hubs with different set of overlays

### DIFF
--- a/dynamic-bgp-on-lo/02-Edge-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Edge-Overlay.j2
@@ -14,7 +14,10 @@
 {% set hubloop = loop %}
 {% set ol_tunnels = [] %}
 {% set backup_tunnel = {} %}
-{% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
+{% for i in project.profiles[profile].interfaces 
+      if i.role == 'wan' and 
+      i.name is defined and
+      i.ol_type in project.hubs[h].overlays %}
   {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
   {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
   {# If no explicit Hub name is defined, then "H<hub_number>" is used #}

--- a/dynamic-bgp-on-lo/02-Hub-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Hub-Overlay.j2
@@ -10,7 +10,10 @@
 {% set multi_vrf = true if project.regions[region].vrfs|default([]) else false %}
 {% set pe_vrf = project.pe_vrf|default(1) if multi_vrf else 0 %}
 
-{% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
+{% for i in project.profiles[profile].interfaces 
+      if i.role == 'wan' and 
+      i.name is defined and
+      i.ol_type in project.hubs[hostname].overlays %}
 config vpn ipsec phase1-interface
   edit "EDGE_{{ i.ol_type }}"
     set type dynamic

--- a/dynamic-bgp-on-lo/03-Hub-Routing.j2
+++ b/dynamic-bgp-on-lo/03-Hub-Routing.j2
@@ -205,7 +205,10 @@ end
 {% endif %}
 {% if project.overlay_stickiness|default(false) %}
 config router policy
-  {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
+  {% for i in project.profiles[profile].interfaces 
+        if i.role == 'wan' and 
+        i.name is defined and 
+        i.ol_type in project.hubs[hostname].overlays %}
   edit {{ loop.index }}
     set input-device "EDGE_{{ i.ol_type }}"
     set output-device "EDGE_{{ i.ol_type }}"

--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -36,6 +36,7 @@
 {% for i in project.profiles[profile].interfaces 
       if i.role == 'wan' and
       i.name is defined and 
+      i.ol_type in project.hubs[hostname].overlays and
       project.hubs[hostname].overlays[i.ol_type].hub2hub|default(true) %}
   {% for r in project.regions if r != region %}
     {% for h in project.regions[r].hubs %}

--- a/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
+++ b/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
@@ -21,6 +21,7 @@
   {% for i in project.profiles[profile].interfaces 
        if i.role == 'wan' and 
        i.name is defined and 
+       i.ol_type in project.hubs[hostname].overlays and
        i.ol_type in project.hubs[h].overlays and
        project.hubs[hostname].overlays[i.ol_type].hub2hub|default(true) and
        project.hubs[h].overlays[i.ol_type].hub2hub|default(true) %}

--- a/dynamic-bgp-on-lo/optional/11-Edge-SDWAN.j2
+++ b/dynamic-bgp-on-lo/optional/11-Edge-SDWAN.j2
@@ -39,7 +39,10 @@ config system sdwan
   end
   config members
   {% set ns = namespace(mbr_i = 1) %}
-  {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined and i.dia|default(false) %}
+  {% for i in project.profiles[profile].interfaces 
+        if i.role == 'wan' and 
+        i.name is defined and 
+        i.dia|default(false) %}
     edit {{ ns.mbr_i }}
       set interface "{{ i.name }}"
       set zone "underlay"
@@ -60,7 +63,10 @@ config system sdwan
   {% set hubloop = loop %}
   {% set this_hub_members = [] %}
   {% set ol_tunnels = [] %}
-  {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
+  {% for i in project.profiles[profile].interfaces 
+        if i.role == 'wan' and 
+        i.name is defined and
+        i.ol_type in project.hubs[h].overlays %}
     {# Track generated tunnels, to handle duplicates by adding extra index as a suffix #}
     {% set ul_name = i.ul_name~"-" if i.ul_name is defined else "" %}
     {# If no explicit Hub name is defined, then "H<hub_number>" is used #}

--- a/dynamic-bgp-on-lo/optional/11-Hub-SDWAN.j2
+++ b/dynamic-bgp-on-lo/optional/11-Hub-SDWAN.j2
@@ -18,7 +18,10 @@ config system sdwan
   end
   config members
     {% set ns = namespace(mbr_i = 1) %}
-    {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined and i.dia|default(false) %}
+    {% for i in project.profiles[profile].interfaces 
+          if i.role == 'wan' and 
+          i.name is defined and 
+          i.dia|default(false) %}
     edit {{ ns.mbr_i }}
       set interface "{{ i.name }}"
       set zone "underlay"
@@ -31,7 +34,10 @@ config system sdwan
     next
     {% set ns.mbr_i = ns.mbr_i + 1 %}
     {% endfor %}
-    {% for i in project.profiles[profile].interfaces if i.role == 'wan' and i.name is defined %}
+    {% for i in project.profiles[profile].interfaces 
+          if i.role == 'wan' and 
+          i.name is defined and 
+          i.ol_type in project.hubs[hostname].overlays %}
     edit {{ ns.mbr_i }}
       set interface "EDGE_{{ i.ol_type }}"
       set zone "overlay"


### PR DESCRIPTION
Previously, we would assume that all Hubs serving a particular region had the same list of overlays. That is, all the overlays must be defined on all the Hubs serving the region.

This is not always the case, as some of the Hubs might have less WAN links than others. 

With this PR, we will automatically skip the non-existing overlays. This applies when we build Spoke-to-Hub tunnels, when we define Dial-Up endpoints on the Hubs and when we build Hub-to-Hub tunnels.

No new configuration is introduced. The skipping is automatic, based on the overlays defined in the `hubs` dictionary. 