### PR TITLE
Add meaninful IKE ID

### DIFF
--- a/dynamic-bgp-on-lo/02-Edge-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Edge-Overlay.j2
@@ -40,6 +40,7 @@ config vpn ipsec phase1-interface
     {% endif %}
     set keylife 28800
     set peertype any
+    set localid {{ ul_name~hostname }}
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost {{ 10 if i.backup|default(false) else 0 }}

--- a/dynamic-bgp-on-lo/02-Hub-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Hub-Overlay.j2
@@ -27,6 +27,7 @@ config vpn ipsec phase1-interface
     set psksecret {{ project.psk|default('S3cr3t!') }}
     {% endif %}
     set peertype any
+    set localid {{ i.ol_type~'-'~hostname }}
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     {% if project.intrareg_advpn|default(true) %}

--- a/dynamic-bgp-on-lo/rendered/deployment_guide/site1-1
+++ b/dynamic-bgp-on-lo/rendered/deployment_guide/site1-1
@@ -89,6 +89,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -129,6 +130,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -169,6 +171,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -209,6 +212,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/deployment_guide/site1-2
+++ b/dynamic-bgp-on-lo/rendered/deployment_guide/site1-2
@@ -103,6 +103,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -143,6 +144,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -183,6 +185,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -223,6 +226,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -263,6 +267,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -303,6 +308,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/deployment_guide/site1-H1
+++ b/dynamic-bgp-on-lo/rendered/deployment_guide/site1-H1
@@ -92,6 +92,7 @@ config vpn ipsec phase1-interface
     set authmethod signature
     set certificate "Hub"
     set peertype any
+    set localid ISP1-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -126,6 +127,7 @@ config vpn ipsec phase1-interface
     set authmethod signature
     set certificate "Hub"
     set peertype any
+    set localid ISP2-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -160,6 +162,7 @@ config vpn ipsec phase1-interface
     set authmethod signature
     set certificate "Hub"
     set peertype any
+    set localid MPLS-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable

--- a/dynamic-bgp-on-lo/rendered/deployment_guide/site1-H2
+++ b/dynamic-bgp-on-lo/rendered/deployment_guide/site1-H2
@@ -92,6 +92,7 @@ config vpn ipsec phase1-interface
     set authmethod signature
     set certificate "Hub"
     set peertype any
+    set localid ISP1-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -126,6 +127,7 @@ config vpn ipsec phase1-interface
     set authmethod signature
     set certificate "Hub"
     set peertype any
+    set localid ISP2-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -160,6 +162,7 @@ config vpn ipsec phase1-interface
     set authmethod signature
     set certificate "Hub"
     set peertype any
+    set localid MPLS-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable

--- a/dynamic-bgp-on-lo/rendered/deployment_guide/site2-1
+++ b/dynamic-bgp-on-lo/rendered/deployment_guide/site2-1
@@ -89,6 +89,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site2-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -129,6 +130,7 @@ config vpn ipsec phase1-interface
     set certificate "Edge"
     set keylife 28800
     set peertype any
+    set localid site2-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/deployment_guide/site2-H1
+++ b/dynamic-bgp-on-lo/rendered/deployment_guide/site2-H1
@@ -84,6 +84,7 @@ config vpn ipsec phase1-interface
     set authmethod signature
     set certificate "Hub"
     set peertype any
+    set localid ISP1-site2-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -118,6 +119,7 @@ config vpn ipsec phase1-interface
     set authmethod signature
     set certificate "Hub"
     set peertype any
+    set localid MPLS-site2-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable

--- a/dynamic-bgp-on-lo/rendered/mixed/site1-1
+++ b/dynamic-bgp-on-lo/rendered/mixed/site1-1
@@ -125,6 +125,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -165,6 +166,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -205,6 +207,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -245,6 +248,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -285,6 +289,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -325,6 +330,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/mixed/site1-2
+++ b/dynamic-bgp-on-lo/rendered/mixed/site1-2
@@ -88,6 +88,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -128,6 +129,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -168,6 +170,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -208,6 +211,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/mixed/site1-3
+++ b/dynamic-bgp-on-lo/rendered/mixed/site1-3
@@ -88,6 +88,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -128,6 +129,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -168,6 +170,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -208,6 +211,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/mixed/site1-H1
+++ b/dynamic-bgp-on-lo/rendered/mixed/site1-H1
@@ -91,6 +91,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP1-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -125,6 +126,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP2-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -159,6 +161,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid MPLS-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable

--- a/dynamic-bgp-on-lo/rendered/mixed/site1-H2
+++ b/dynamic-bgp-on-lo/rendered/mixed/site1-H2
@@ -91,6 +91,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP1-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -125,6 +126,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP2-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -159,6 +161,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid MPLS-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable

--- a/dynamic-bgp-on-lo/rendered/mixed/site2-1
+++ b/dynamic-bgp-on-lo/rendered/mixed/site2-1
@@ -88,6 +88,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site2-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -128,6 +129,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site2-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/mixed/site2-H1
+++ b/dynamic-bgp-on-lo/rendered/mixed/site2-H1
@@ -91,6 +91,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP1-site2-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -125,6 +126,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP2-site2-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -159,6 +161,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid MPLS-site2-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable

--- a/dynamic-bgp-on-lo/rendered/multi_vrf/site1-1
+++ b/dynamic-bgp-on-lo/rendered/multi_vrf/site1-1
@@ -125,6 +125,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -165,6 +166,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -205,6 +207,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -245,6 +248,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -285,6 +289,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -325,6 +330,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/multi_vrf/site1-2
+++ b/dynamic-bgp-on-lo/rendered/multi_vrf/site1-2
@@ -111,6 +111,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -151,6 +152,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -191,6 +193,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -231,6 +234,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site1-2
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/multi_vrf/site1-H1
+++ b/dynamic-bgp-on-lo/rendered/multi_vrf/site1-H1
@@ -91,6 +91,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP1-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -125,6 +126,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP2-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -159,6 +161,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid MPLS-site1-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable

--- a/dynamic-bgp-on-lo/rendered/multi_vrf/site1-H2
+++ b/dynamic-bgp-on-lo/rendered/multi_vrf/site1-H2
@@ -91,6 +91,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP1-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -125,6 +126,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP2-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -159,6 +161,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid MPLS-site1-H2
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable

--- a/dynamic-bgp-on-lo/rendered/multi_vrf/site2-1
+++ b/dynamic-bgp-on-lo/rendered/multi_vrf/site2-1
@@ -111,6 +111,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site2-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0
@@ -151,6 +152,7 @@ config vpn ipsec phase1-interface
     set psksecret S3cr3t!
     set keylife 28800
     set peertype any
+    set localid site2-1
     set exchange-fgt-device-id enable
     set net-device enable
     set link-cost 0

--- a/dynamic-bgp-on-lo/rendered/multi_vrf/site2-H1
+++ b/dynamic-bgp-on-lo/rendered/multi_vrf/site2-H1
@@ -91,6 +91,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP1-site2-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -125,6 +126,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid ISP2-site2-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable
@@ -159,6 +161,7 @@ config vpn ipsec phase1-interface
     set authmethod psk
     set psksecret S3cr3t!
     set peertype any
+    set localid MPLS-site2-H1
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set auto-discovery-sender enable


### PR DESCRIPTION
To simplify troubleshooting of the SD-WAN network, we add meaninful IKE IDs to all Hubs and Spokes, with the following convention:

- Each Dial-Up on the Hub will have the ID `<ol_type>-<hostname>` (for example, "INET-site1-H1")

- Each Hub-facing tunnel on the Spoke will have the ID `<ul_name>-<hostname>` (for example, "LTE-site1-1"). If the `ul_name` is not set on the respective interface, the ID will be simply `<hostname>`

