### PR TITLE
Support certificate filtering during IPSEC authentication

### DIFF
--- a/dynamic-bgp-on-lo/02-Edge-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Edge-Overlay.j2
@@ -34,12 +34,15 @@ config vpn ipsec phase1-interface
     {% if project.cert_auth|default(true) %}
     set authmethod signature
     set certificate "{{ project.edge_cert_template|default('Edge') }}"
+    set peertype {{ 'peer' if project.cert_auth_filter|default(false) else 'any' }}
+      {% if project.cert_auth_filter|default(false) %}
+      set peer {{ project.edge_cert_filter|default('TheCA') }}
+      {% endif %}
     {% else %}
     set authmethod psk
     set psksecret {{ project.psk|default('S3cr3t!') }}
     {% endif %}
     set keylife 28800
-    set peertype any
     set localid {{ ul_name~hostname }}
     set exchange-fgt-device-id enable
     set net-device enable

--- a/dynamic-bgp-on-lo/02-Edge-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Edge-Overlay.j2
@@ -40,6 +40,7 @@ config vpn ipsec phase1-interface
       {% endif %}
     {% else %}
     set authmethod psk
+    set peertype any
     set psksecret {{ project.psk|default('S3cr3t!') }}
     {% endif %}
     set keylife 28800

--- a/dynamic-bgp-on-lo/02-Hub-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Hub-Overlay.j2
@@ -28,6 +28,7 @@ config vpn ipsec phase1-interface
       {% endif %}    
     {% else %}
     set authmethod psk
+    set peertype any
     set psksecret {{ project.psk|default('S3cr3t!') }}
     {% endif %}
     set localid {{ i.ol_type~'-'~hostname }}

--- a/dynamic-bgp-on-lo/02-Hub-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Hub-Overlay.j2
@@ -22,11 +22,14 @@ config vpn ipsec phase1-interface
     {% if project.cert_auth|default(true) %}
     set authmethod signature
     set certificate "{{ project.hub_cert_template|default('Hub') }}"
+    set peertype {{ 'peer' if project.cert_auth_filter|default(false) else 'any' }}
+      {% if project.cert_auth_filter|default(false) %}
+      set peer {{ project.hub_cert_filter|default('TheCA') }}
+      {% endif %}    
     {% else %}
     set authmethod psk
     set psksecret {{ project.psk|default('S3cr3t!') }}
     {% endif %}
-    set peertype any
     set localid {{ i.ol_type~'-'~hostname }}
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256

--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -52,12 +52,15 @@
           {% if project.cert_auth|default(true) %}
           set authmethod signature
           set certificate "{{ project.hub_cert_template|default('Hub') }}"
+          set peertype {{ 'peer' if project.cert_auth_filter|default(false) else 'any' }}
+            {% if project.cert_auth_filter|default(false) %}
+            set peer {{ project.hub_cert_filter_hub2hub|default('TheCA') }}
+            {% endif %}    
           {% else %}
           set authmethod psk
           set psksecret {{ project.psk|default('S3cr3t!') }}
           {% endif %}
           set keylife 28800
-          set peertype any
           set exchange-fgt-device-id enable
           set proposal aes256gcm-prfsha256
           {% if project.multireg_advpn|default(true) %}

--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -58,6 +58,7 @@
             {% endif %}    
           {% else %}
           set authmethod psk
+          set peertype any
           set psksecret {{ project.psk|default('S3cr3t!') }}
           {% endif %}
           set keylife 28800

--- a/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
+++ b/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
@@ -38,10 +38,10 @@
         {% endif %}    
       {% else %}
       set authmethod psk
+      set peertype any
       set psksecret {{ project.psk|default('S3cr3t!') }}
       {% endif %}
       set keylife 28800
-      set peertype any
       set exchange-fgt-device-id enable
       set proposal aes256gcm-prfsha256
       set exchange-interface-ip enable

--- a/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
+++ b/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
@@ -32,6 +32,10 @@
       {% if project.cert_auth|default(true) %}
       set authmethod signature
       set certificate "{{ project.hub_cert_template|default('Hub') }}"
+      set peertype {{ 'peer' if project.cert_auth_filter|default(false) else 'any' }}
+        {% if project.cert_auth_filter|default(false) %}
+        set peer {{ project.hub_cert_filter_hub2hub|default('TheCA') }}
+        {% endif %}    
       {% else %}
       set authmethod psk
       set psksecret {{ project.psk|default('S3cr3t!') }}


### PR DESCRIPTION
By default, when certificate-based IPSEC authentication is implemented, we accept any valid and trusted certificate. 
Users may want to restrict the list of accepted certificates. 

The most common example is to restrict the list of trusted CAs, because the full list of CAs trusted by the FortiGate normally contains the default Fortinet CA, it might contain public Internet CAs and so on. For the SD-WAN overlay network, the user might want to restrict the list only to the CA actually used to issue the SD-WAN node certificates (it could be a built-in FortiManager CA or an external corporate CA). Optionally, the user may want to add other constraints too. 

FOS supports certificate filtering using the `config user peer` object that is then referred under the IPSEC configuration. At the moment, we do not plan generating that object, because it would require to pass to the Jinja Orchestrator the actual names of the CA certificates the user would like to trust, as well as any other FOS-supported parameters. Instead, we add the capability to add this object to the generated IPSEC configuration, assuming that the object itself has been created by the user elsewhere (for example, using the FortiManager GUI or using an additional CLI Template added by the user). 

This way, we leave it to the user to define any type of constraints and any list of trusted CAs they may desire. We will simply reference the object in the IPSEC configuration, as follows:

```
config vpn ipsec phase1-interface
  edit "{{ ol_tun_name }}"
    set authmethod signature
    set peertype peer
    set peer "TheCA"
    ...
```

**Configuration**

To enable this functionality (on all Hubs and Spokes, including the Hub-to-Hub tunnels), the following two global options must be configured:

```j2
# Enable certificate-based IPSEC authentication (enabled by default)
{% set cert_auth = true %} 

# Enable certificate filtering (new feature, disabled by default)
{% set cert_auth_filter = true %}
```

**Naming Convention**

By default, we expect the `config user peer` object called **"TheCA"**. 
Its content can be anything supported by the FOS.

The name can be customized, using the following global optional parameters:

```j2
# On the Spokes (configured on the Spoke-to-Hub tunnels)
{% set edge_cert_filter = "MyOwnCA" %}

# On the Hubs (configured on the Spoke-facing Dial-Up tunnels)
{% set hub_cert_filter = "MyOwnCA" %}

# On the Hubs (configured on the Hub-to-Hub tunnels, both within and between regions)
{% set hub_cert_filter_hub2hub = "MyOwnCA" %}
```

**Example**

Here is an example of the `config user peer` object limiting the list of trusted CAs. 
This configuration is **NOT** generated by the Jinja Orchestrator, it is prepared by the user elsewhere.

```
config user peer
    edit "TheCA"
        set ca "CustomerA_CA3"
    next
end
```