### PR TITLE
Support LAG (802.3ad Aggregate Interfaces)

### DIFF
--- a/dynamic-bgp-on-lo/01-Edge-Underlay.j2
+++ b/dynamic-bgp-on-lo/01-Edge-Underlay.j2
@@ -115,7 +115,7 @@ config system interface
     {% elif i.role == 'trunk' %}
     set trunk {{ 'enable' if vlan_switch else 'disable' }}
     {% endif %}
-    {% if i.ip is defined %}
+    {% if i.ip is defined and i.role in [ 'lan', 'wan' ] %}
     set allowaccess {{ 'ping' if not i.access|default(false) else i.access|join(' ') }}
     {% endif %}
   next

--- a/dynamic-bgp-on-lo/01-Edge-Underlay.j2
+++ b/dynamic-bgp-on-lo/01-Edge-Underlay.j2
@@ -75,6 +75,20 @@ config system interface
     set interface {{ i.parent }}
     {% endif %}
 
+    {# Aggregate (LAG) #}
+    {% set lag_members = [] %}
+    {% if i.aggregate|default(false) %}
+    set vdom "root"
+    set type aggregate
+    {% for j in project.profiles[profile].interfaces 
+          if j.role == 'lag_member' and 
+          j.parent == i.name and 
+          j.name is defined %}
+    {{ lag_members.append(j.name) or "" }}
+    {% endfor %}
+    {{'un' if not lag_members}}set member {{ lag_members|join(' ') }}
+    {% endif %}     
+
     {# FEX #}
     {% if i.fex|default(false) %}
     set type fext-wan

--- a/dynamic-bgp-on-lo/01-Hub-Underlay.j2
+++ b/dynamic-bgp-on-lo/01-Hub-Underlay.j2
@@ -47,6 +47,20 @@ config system interface
     set interface {{ i.parent }}
     {% endif %}
 
+    {# Aggregate (LAG) #}
+    {% set lag_members = [] %}
+    {% if i.aggregate|default(false) %}
+    set vdom "root"
+    set type aggregate
+    {% for j in project.profiles[profile].interfaces 
+          if j.role == 'lag_member' and 
+          j.parent == i.name and 
+          j.name is defined %}
+    {{ lag_members.append(j.name) or "" }}
+    {% endfor %}
+    {{'un' if not lag_members}}set member {{ lag_members|join(' ') }}
+    {% endif %}       
+
     {# Other settings #}
     {% if i.role == 'wan' %}
     set role wan


### PR DESCRIPTION
One or more LAGs can be defined in the device profile. 

- The LAG Interface itself is identified by setting `aggregate` to 'true'. Apart from that, it is configured as any other L3 interface (e.g. it can be WAN-facing or LAN-facing, there can be additional VLAN interfaces defined on top of it and so on).
- The LAG members are identified by setting  their `role` to 'lag_member'. They must also set their `parent` to the name of the LAG interface.

Example (here two physical interfaces `internal1` and `internal2` form a LAG called `lag_lan`):

```j2
{% set profiles = {
    'MyBranch': {
      'interfaces': [
        {
          'name': 'lag_lan',
          'role': 'lan',
          'ip': lan_ip,
          'aggregate': true
        },
        {
          'name': 'internal1',
          'role': 'lag_member',
          'parent': 'lag_lan'
        },
        {
          'name': 'internal2',
          'role': 'lag_member',
          'parent': 'lag_lan'
        }
      ]
    }     

  }
%}
```

Here is a more complex example, with two VLANs defined on top of the LAG (note the `role` set to 'undefined' on the LAG interface):

```j2
{% set profiles = {
    'MyBranch': {
      'interfaces': [
         {
            'name': 'lag_lan',
            'role': 'undefined',
            'aggregate': true
         },
         {
            'name': 'internal1',
            'role': 'lag_member',
            'parent': 'lag_lan'
         },
         {
            'name': 'internal2',
            'role': 'lag_member',
            'parent': 'lag_lan'
         },         
         {
             'name': 'vl_users',
             'role': 'lan',
             'ip': users_ip,
             'vlanid': 10,
             'parent': 'lag_lan'
         },
         {
             'name': 'vl_servers',
             'role': 'lan',
             'ip': servers_ip,
             'vlanid': 20,
             'parent': 'lag_lan'
         }       
       ]
    }     

  }
%}
```