### PR TITLE
Support non-root vdom

### DIFF
--- a/dynamic-bgp-on-lo/01-Edge-Underlay.j2
+++ b/dynamic-bgp-on-lo/01-Edge-Underlay.j2
@@ -10,6 +10,17 @@
 {% set multi_vrf = true if project.regions[region].vrfs|default([]) else false %}
 {% set pe_vrf = project.pe_vrf|default(1) if multi_vrf else 0 %}
 
+{# Options: project-wide defaults #}
+{% set options = {
+    'vdom': project.vdom|default('root')
+  }
+%}
+{# Options can be selectively overriden in profile #}
+{% set _ = options.update(
+      project.profiles[profile].options|default({})
+   ) 
+%}
+
 {# General settings #}
 config system settings
   set location-id {{ loopback|ipaddr('address') }}
@@ -69,7 +80,7 @@ config system interface
 
     {# VLAN #}
     {% if i.vlanid is defined and i.parent is defined %}
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type vlan
     set vlanid {{ i.vlanid }}
     set interface {{ i.parent }}
@@ -78,7 +89,7 @@ config system interface
     {# Aggregate (LAG) #}
     {% set lag_members = [] %}
     {% if i.aggregate|default(false) %}
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type aggregate
     {% for j in project.profiles[profile].interfaces 
           if j.role == 'lag_member' and 
@@ -152,7 +163,7 @@ end
 {% if i.role == 'wan' and i.src_ip is defined %}
 config system interface
   edit "Lo-wan{{ loop.index }}"
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type loopback
     set vrf {{ pe_vrf }}
     set ip {{ i.src_ip|ipaddr('address') }}/32
@@ -167,7 +178,7 @@ end
 {# Main Loopback #}
 config system interface
   edit "Lo"
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type loopback
     set vrf {{ pe_vrf }}
     set ip {{ loopback|ipaddr('address') }}/32

--- a/dynamic-bgp-on-lo/01-Hub-Underlay.j2
+++ b/dynamic-bgp-on-lo/01-Hub-Underlay.j2
@@ -10,6 +10,17 @@
 {% set multi_vrf = true if project.regions[region].vrfs|default([]) else false %}
 {% set pe_vrf = project.pe_vrf|default(1) if multi_vrf else 0 %}
 
+{# Options: project-wide defaults #}
+{% set options = {
+    'vdom': project.vdom|default('root')
+  }
+%}
+{# Options can be selectively overriden in profile #}
+{% set _ = options.update(
+      project.profiles[profile].options|default({})
+   ) 
+%}
+
 {# General settings #}
 config system settings
   set location-id {{ loopback|ipaddr('address') }}
@@ -41,7 +52,7 @@ config system interface
 
     {# VLAN #}
     {% if i.vlanid is defined and i.parent is defined %}
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type vlan
     set vlanid {{ i.vlanid }}
     set interface {{ i.parent }}
@@ -50,7 +61,7 @@ config system interface
     {# Aggregate (LAG) #}
     {% set lag_members = [] %}
     {% if i.aggregate|default(false) %}
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type aggregate
     {% for j in project.profiles[profile].interfaces 
           if j.role == 'lag_member' and 
@@ -77,7 +88,7 @@ end
 {% if i.role == 'wan' and i.src_ip is defined %}
 config system interface
   edit "Lo-wan{{ loop.index }}"
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type loopback
     set vrf {{ pe_vrf }}
     set ip {{ i.src_ip|ipaddr('address') }}/32
@@ -92,7 +103,7 @@ end
 {# Loopback for incoming health-check probes #}
 config system interface
   edit "Lo-HC"
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type loopback
     set vrf {{ pe_vrf }}
     set ip {{ project.hub_hc_server|default('10.200.99.1') }}/32
@@ -100,7 +111,7 @@ config system interface
   next
   {# Main Loopback #}
   edit "Lo"
-    set vdom "root"
+    set vdom {{ options.vdom }}
     set type loopback
     set vrf {{ pe_vrf }}
     set ip {{ loopback|ipaddr('address') }}/32

--- a/dynamic-bgp-on-lo/04-Edge-InterVRF.j2
+++ b/dynamic-bgp-on-lo/04-Edge-InterVRF.j2
@@ -13,6 +13,7 @@
 
 {# Options: project-wide defaults #}
 {% set options = {
+    'vdom': project.vdom|default('root'),
     'leak_npu_link': '',
     'force_cleanup': project.force_cleanup|default(false)
   }
@@ -53,14 +54,14 @@
     edit "vrf{{ i.vrf }}_leak0"
       set type vdom-link
       set vrf {{ pe_vrf }}
-      set vdom 'root'
+      set vdom {{ options.vdom }}
       set ip {{ vrf_leak_summary|ipaddr((i.vrf * 2 + 1))|ipaddr('address') }}/31
       set allowaccess ping
     next
     edit "vrf{{ i.vrf }}_leak1"
       set type vdom-link
       set vrf {{ i.vrf }}
-      set vdom 'root'
+      set vdom {{ options.vdom }}
       set ip {{ vrf_leak_summary|ipaddr((i.vrf * 2))|ipaddr('address') }}/31
       set allowaccess ping
     next
@@ -73,7 +74,7 @@
       set vlanid {{ 4000 + i.vrf }}
       set interface "{{options.leak_npu_link}}0"
       set vrf {{ pe_vrf }}
-      set vdom 'root'
+      set vdom {{ options.vdom }}
       set mode static
       set ip {{ vrf_leak_summary|ipaddr((i.vrf * 2 + 1))|ipaddr('address') }}/31
       set allowaccess ping
@@ -83,7 +84,7 @@
       set vlanid {{ 4000 + i.vrf }}
       set interface "{{options.leak_npu_link}}1"
       set vrf {{ i.vrf }}
-      set vdom 'root'
+      set vdom {{ options.vdom }}
       set mode static
       set ip {{ vrf_leak_summary|ipaddr((i.vrf * 2))|ipaddr('address') }}/31
       set allowaccess ping

--- a/dynamic-bgp-on-lo/06-Hub-InterVRF.j2
+++ b/dynamic-bgp-on-lo/06-Hub-InterVRF.j2
@@ -13,6 +13,7 @@
 
 {# Options: project-wide defaults #}
 {% set options = {
+    'vdom': project.vdom|default('root'),
     'leak_npu_link': '',
     'force_cleanup': project.force_cleanup|default(false)
   }
@@ -53,14 +54,14 @@
     edit "vrf{{ i.vrf }}_leak0"
       set type vdom-link
       set vrf {{ pe_vrf }}
-      set vdom 'root'
+      set vdom {{ options.vdom }}
       set ip {{ vrf_leak_summary|ipaddr((i.vrf * 2 + 1))|ipaddr('address') }}/31
       set allowaccess ping
     next
     edit "vrf{{ i.vrf }}_leak1"
       set type vdom-link
       set vrf {{ i.vrf }}
-      set vdom 'root'
+      set vdom {{ options.vdom }}
       set ip {{ vrf_leak_summary|ipaddr((i.vrf * 2))|ipaddr('address') }}/31
       set allowaccess ping
     next
@@ -73,7 +74,7 @@
       set vlanid {{ 4000 + i.vrf }}
       set interface "{{options.leak_npu_link}}0"
       set vrf {{ pe_vrf }}
-      set vdom 'root'
+      set vdom {{ options.vdom }}
       set mode static
       set ip {{ vrf_leak_summary|ipaddr((i.vrf * 2 + 1))|ipaddr('address') }}/31
       set allowaccess ping
@@ -83,7 +84,7 @@
       set vlanid {{ 4000 + i.vrf }}
       set interface "{{options.leak_npu_link}}1"
       set vrf {{ i.vrf }}
-      set vdom 'root'
+      set vdom {{ options.vdom }}
       set mode static
       set ip {{ vrf_leak_summary|ipaddr((i.vrf * 2))|ipaddr('address') }}/31
       set allowaccess ping

--- a/dynamic-bgp-on-lo/07-Hub-Services.j2
+++ b/dynamic-bgp-on-lo/07-Hub-Services.j2
@@ -9,6 +9,7 @@
 
 {# Options: project-wide defaults #}
 {% set options = {
+    'vdom': project.vdom|default('root'),   
     'force_cleanup': project.force_cleanup|default(false)
   }
 %}
@@ -24,7 +25,7 @@ config vpn certificate crl
    edit TheCA
       {{'un' if not project.crl_scep_url|default()}}set scep-url {{ project.crl_scep_url|default() }}
       {{'un' if not project.crl_http_url|default()}}set http-url {{ project.crl_http_url|default() }}
-      set update-vdom "root"
+      set update-vdom {{ options.vdom }}
       set update-interval 300
    next
 end


### PR DESCRIPTION
By default, it is assumed that the SD-WAN is configured in the "root" VDOM. If this is not the case, it is now possible to specify the VDOM name, using `vdom` parameter. 

This optional parameter can be set either globally (for the entire project):

```j2
{% set vdom = "CustX" %}
```

...or per profile (this overrides the global value):

```j2
{% set profiles = {
    'MultiVdomBranch': {
      'options': {
        'vdom': "CustX"
      },
      'interfaces': [
        # ...
      ]
    }
  }
%}
```

Note that we DO NOT support multiple SD-WAN VDOMs on the same device. For example, we generate several special interfaces with fixed names (such as "Lo", "Lo-HC"...), and this would cause conflicts if you tried to do it in multiple VDOMs. 
That is why there must be only one SD-WAN VDOM on the device. It's just that it doesn't have to be the "root" VDOM.

The "root" VDOM is still the default choice, when the `vdom` parameter is not set (neither in the profile nor globally).