### PR TITLE
Support Redundant Interfaces

### DIFF
--- a/dynamic-bgp-on-lo/01-Edge-Underlay.j2
+++ b/dynamic-bgp-on-lo/01-Edge-Underlay.j2
@@ -86,11 +86,11 @@ config system interface
     set interface {{ i.parent }}
     {% endif %}
 
-    {# Aggregate (LAG) #}
+    {# Aggregate (LAG) and Redundant Interfaces #}
     {% set lag_members = [] %}
-    {% if i.aggregate|default(false) %}
+    {% if i.aggregate|default(false) or i.redundant|default(false) %}
     set vdom {{ options.vdom }}
-    set type aggregate
+    set type {{ 'aggregate' if i.aggregate|default(false) else 'redundant' }}
     {% for j in project.profiles[profile].interfaces 
           if j.role == 'lag_member' and 
           j.parent == i.name and 

--- a/dynamic-bgp-on-lo/01-Hub-Underlay.j2
+++ b/dynamic-bgp-on-lo/01-Hub-Underlay.j2
@@ -58,11 +58,11 @@ config system interface
     set interface {{ i.parent }}
     {% endif %}
 
-    {# Aggregate (LAG) #}
+    {# Aggregate (LAG) and Redundant Interfaces #}
     {% set lag_members = [] %}
-    {% if i.aggregate|default(false) %}
+    {% if i.aggregate|default(false) or i.redundant|default(false) %}
     set vdom {{ options.vdom }}
-    set type aggregate
+    set type {{ 'aggregate' if i.aggregate|default(false) else 'redundant' }}
     {% for j in project.profiles[profile].interfaces 
           if j.role == 'lag_member' and 
           j.parent == i.name and 
@@ -70,7 +70,7 @@ config system interface
     {{ lag_members.append(j.name) or "" }}
     {% endfor %}
     {{'un' if not lag_members}}set member {{ lag_members|join(' ') }}
-    {% endif %}       
+    {% endif %}        
 
     {# Other settings #}
     {% if i.role == 'wan' %}


### PR DESCRIPTION
Similar to the recently added Aggregate (LAG) support, we now also support Redundant Interfaces (read more about it here: 
https://docs.fortinet.com/document/fortigate/7.4.7/administration-guide/567758/aggregation-and-redundancy).

The configuration is similar to the Aggregate, except that we use `redundant` parameter (instead of `aggregate`) to identify the Redundant Interface in the device profile:

- The Redundant Interface itself is identified by setting `redundant` to 'true'. Apart from that, it is configured as any other L3 interface (e.g. it can be WAN-facing or LAN-facing, there can be additional VLAN interfaces defined on top of it and so on).

- The Redundant members are identified by setting their role to 'lag_member'. They must also set their parent to the name of the Redundant Interface.

Example (here two physical interfaces internal1 and internal2 form a Redundant Interface called `redundant_lan`):

```j2
{% set profiles = {
    'MyBranch': {
      'interfaces': [
        {
          'name': 'redundant_lan',
          'role': 'lan',
          'ip': lan_ip,
          'redundant': true
        },
        {
          'name': 'internal1',
          'role': 'lag_member',
          'parent': 'redundant_lan'
        },
        {
          'name': 'internal2',
          'role': 'lag_member',
          'parent': 'redundant_lan'
        }
      ]
    }     

  }
%}
```