### PR TITLE
Support backbone interfaces for Hub-to-Hub tunnels (new 'backbone' role)

### DIFF
--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -34,7 +34,7 @@
 {# Build Hub-to-Hub tunnels #}
 
 {% for i in project.profiles[profile].interfaces 
-      if i.role == 'wan' and
+      if i.role in [ 'wan', 'backbone' ] and
       i.name is defined and 
       i.ol_type in project.hubs[hostname].overlays and
       project.hubs[hostname].overlays[i.ol_type].hub2hub|default(true) %}

--- a/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
+++ b/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
@@ -19,7 +19,7 @@
 {% for h in project.regions[region].hubs if h != hostname %}
   {% set peer_index = project.regions[region].hubs.index(h) + 1 %}
   {% for i in project.profiles[profile].interfaces 
-       if i.role == 'wan' and 
+       if i.role in [ 'wan', 'backbone' ] and 
        i.name is defined and 
        i.ol_type in project.hubs[hostname].overlays and
        i.ol_type in project.hubs[h].overlays and


### PR DESCRIPTION
Add a new interface role `backbone`. 

A backbone interface has a meaning only on Hubs. It is used for Hub-to-Hub tunnels (both intra-regional and inter-regional). It is not used for the Hub-to-Spoke connectivity (therefore, the IPSEC Dial-Up endpoints are not generated on the backbone interfaces). 

The interface configuration is similar to the `wan` role. Also here we must set the `ol_type` which must refer to an overlay defined on the target Hub. Normally, this will be a dedicated overlay for the backbone Hub-to-Hub connectivity, as shown in the example below. 

Remember that, by default, we generate Hub-to-Hub tunnels on all the WAN interfaces too (those with `wan` role). But when you define a backbone, you might want to generate them _only_ over the backbone. In that case, you must set `hub2hub = false` for all the overlays referred by the WAN interfaces (as explained [here](https://github.com/fortinet-solutions-cse/sdwan-advpn-reference/wiki/04-Overlay-Customization#multi-regional-support)).

**Example:**

Here we have a Hub profile as follows:

- "port1" is a WAN interface. An overlay called "INET" is configurd over it. A Dial-Up endpoint called "EDGE_INET" will be generated for the Spoke tunnels. No Hub-to-Hub tunnels will be generated, because the "hub2hub" parameter is set to "false" for this overlay.

- "port7" is a backbone interface. An overlay called "BB" is configured over it. No Dial-Up endpoints will be generated here. But the Hub-to-Hub tunnels will be generated. In our example, on the Hub "site1-H1" there will be a tunnel generated towards the remote region "East". This tunnel will be called "EAST_H1_BB". 

```j2
{# Regions #}
{% set regions = {
    'West': {
      'as': '65001',
      'lo_summary': '10.200.1.0/24',
      'lan_summary': '10.0.0.0/14',
      'hubs': [ 'site1-H1' ]
    },
    'East': {
      'as': '65002',
      'lo_summary': '10.200.2.0/24',
      'lan_summary': '10.4.0.0/14',
      'hubs': [ 'site2-H1' ]
    }
  }
%}

{# Device Profiles #}
{% set profiles = {

   'Hub': {
      'interfaces': [
         {
            'name': 'port1',
            'role': 'wan',
            'ol_type': 'INET',
            'ip': 'dhcp'
         },
         {
            'name': 'port7',
            'role': 'backbone',
            'ol_type': 'BB',
            'ip': 'dhcp'
         }
      ]
   }

  }
%}

{# Hubs #}
{% set hubs = {

    'site1-H1': {
      'lo_bgp': '10.200.1.253',
      'overlays': {
        'INET': {
          'wan_ip': '100.64.1.1'
        },
        'BB': {
          'wan_ip': '172.16.1.5'
        }
      }
    },

    'site2-H1': {
      'lo_bgp': '10.200.2.253',      
      'overlays': {
        'INET': {
          'wan_ip': '100.64.4.1'
        },
        'BB': {
          'wan_ip': '172.16.4.5'
        }
      }
    }    

  }
%}
```