### PR TITLE
Support PQC for IPSEC key exchange

### DIFF
--- a/dynamic-bgp-on-lo/02-Edge-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Edge-Overlay.j2
@@ -12,7 +12,8 @@
 
 {# Options: project-wide defaults #}
 {% set options = {
-    'advpn2': project.advpn2|default(true)
+    'advpn2': project.advpn2|default(true),
+    'pqc': project.pqc|default(false)
   }
 %}
 {# Options can be selectively overriden in profile #}
@@ -61,6 +62,8 @@ config vpn ipsec phase1-interface
     set net-device enable
     set link-cost {{ 10 if i.backup|default(false) else 0 }}
     set proposal aes256gcm-prfsha256 aes256-sha256
+    set dhgrp 20 21
+    {{ 'set addke1 36' if options.pqc else 'unset addke1' }}
     set idle-timeout enable
     set shared-idle-timeout {{ 'enable' if options.advpn2 else 'disable' }}
     {% if project.intrareg_advpn|default(true) %}
@@ -103,6 +106,7 @@ config vpn ipsec phase2-interface
   edit "{{ ol_tun_name }}"
     set phase1name "{{ ol_tun_name }}"
     set proposal aes256gcm
+    {{ 'set addke1 36' if options.pqc else 'unset addke1' }}
     set keepalive enable
     set keylifeseconds 3600
   next

--- a/dynamic-bgp-on-lo/02-Hub-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Hub-Overlay.j2
@@ -35,6 +35,8 @@ config vpn ipsec phase1-interface
     set localid {{ i.ol_type~'-'~hostname }}
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
+    set dhgrp 20 21
+    set addke1 36 0
     {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-sender enable
     {% else %}
@@ -64,6 +66,7 @@ config vpn ipsec phase2-interface
   edit "EDGE_{{ i.ol_type }}"
     set phase1name "EDGE_{{ i.ol_type }}"
     set proposal aes256gcm
+    set addke1 36 0
     set keepalive enable
   next
 end

--- a/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
+++ b/dynamic-bgp-on-lo/04-Hub-MultiRegion.j2
@@ -19,7 +19,8 @@
 {# Options: project-wide defaults #}
 {% set options = {
     'force_cleanup': project.force_cleanup|default(false),
-    'spoke2hub_advpn': project.spoke2hub_advpn|default(false)
+    'spoke2hub_advpn': project.spoke2hub_advpn|default(false),
+    'pqc': project.pqc|default(false)
   }
 %}
 {# Options can be selectively overriden in profile #}
@@ -65,6 +66,8 @@
           set keylife 28800
           set exchange-fgt-device-id enable
           set proposal aes256gcm-prfsha256
+          set dhgrp 20 21
+          {{ 'set addke1 36 0' if options.pqc else 'unset addke1' }}
           {% if project.multireg_advpn|default(true) %}
           set auto-discovery-sender enable
           set auto-discovery-receiver enable
@@ -89,6 +92,7 @@
         edit "{{ ol_tun_name }}"
           set phase1name "{{ ol_tun_name }}"
           set proposal aes256gcm
+          {{ 'set addke1 36 0' if options.pqc else 'unset addke1' }}
           set keepalive enable
           set keylifeseconds 3600
         next

--- a/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
+++ b/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
@@ -10,10 +10,6 @@
 {% set multi_vrf = true if project.regions[region].vrfs|default([]) else false %}
 {% set pe_vrf = project.pe_vrf|default(1) if multi_vrf else 0 %}
 
-{# Hub2Hub tunnels within the region (for DC-to-DC traffic) #}
-{% set my_index = project.regions[region].hubs.index(hostname) + 1 %}
-{% if project.intrareg_hub2hub|default(false) %}
-
 {# Options: project-wide defaults #}
 {% set options = {
     'pqc': project.pqc|default(false)
@@ -24,6 +20,10 @@
       project.profiles[profile].options|default({})
    ) 
 %}
+
+{# Hub2Hub tunnels within the region (for DC-to-DC traffic) #}
+{% set my_index = project.regions[region].hubs.index(hostname) + 1 %}
+{% if project.intrareg_hub2hub|default(false) %}
 
 {# Build Hub-to-Hub tunnels #}
 

--- a/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
+++ b/dynamic-bgp-on-lo/05-Hub-IntraRegion.j2
@@ -14,6 +14,17 @@
 {% set my_index = project.regions[region].hubs.index(hostname) + 1 %}
 {% if project.intrareg_hub2hub|default(false) %}
 
+{# Options: project-wide defaults #}
+{% set options = {
+    'pqc': project.pqc|default(false)
+  }
+%}
+{# Options can be selectively overriden in profile #}
+{% set _ = options.update(
+      project.profiles[profile].options|default({})
+   ) 
+%}
+
 {# Build Hub-to-Hub tunnels #}
 
 {% for h in project.regions[region].hubs if h != hostname %}
@@ -45,6 +56,8 @@
       set keylife 28800
       set exchange-fgt-device-id enable
       set proposal aes256gcm-prfsha256
+      set dhgrp 20 21
+      {{ 'set addke1 36 0' if options.pqc else 'unset addke1' }}
       set exchange-interface-ip enable
       set encapsulation {{ 'vpn-id-ipip' if multi_vrf else 'none' }}
       set remote-gw {{ project.hubs[h].overlays[i.ol_type].wan_ip }}
@@ -59,6 +72,7 @@
     edit "H{{ my_index }}H{{ peer_index }}_{{ i.ol_type }}"
       set phase1name "H{{ my_index }}H{{ peer_index }}_{{ i.ol_type }}"
       set proposal aes256gcm
+      {{ 'set addke1 36 0' if options.pqc else 'unset addke1' }}
       set keepalive enable
       set keylifeseconds 3600    
     next


### PR DESCRIPTION
Post-Quantum Cryptography (PQC) can be applied to all the IPSEC tunnels generated by the Jinja Orchestrator 
(including Spoke-to-Hub and Hub-to-Hub tunnels). It can be enabled either globally or on a per-profile basis.

Note that PQC will always be allowed (but not mandated) on the Hubs for the Spoke-to-Hub tunnels.
Therefore, if the global PQC option is not enabled, it can be enabled on a particular Spoke profile, 
allowing PQC to be used only by those Spokes, while the others will keep communicating with the Hub without PQC. 
This method allows gradual rollout of the PQC.

The global PQC option can be enabled as follows (in this case, it will apply to all Spokes and Hubs):

```j2
{% set pqc = true %}
```

And here is an example of the PQC enabled only on a specific profile (e.g. to apply it only to certain Spokes):

```j2
{% set profiles = {
    'SafeSpoke': {
      'options': {
        'pqc': true
      },
      'interfaces': [
        # ...
      ]
    }
  }
%}
```