### PR TITLE
Conditionalize addke1 setting based on options.pqc on 02-Hub-Overlay.j2

### DIFF
--- a/dynamic-bgp-on-lo/02-Hub-Overlay.j2
+++ b/dynamic-bgp-on-lo/02-Hub-Overlay.j2
@@ -37,7 +37,7 @@ config vpn ipsec phase1-interface
     set exchange-fgt-device-id enable
     set proposal aes256gcm-prfsha256 aes256-sha256
     set dhgrp 20 21 14
-    set addke1 36 0
+    {{ 'set addke1 36 0' if options.pqc else 'unset addke1' }}
     {% if project.intrareg_advpn|default(true) %}
     set auto-discovery-sender enable
     {% else %}
@@ -68,7 +68,7 @@ config vpn ipsec phase2-interface
     set phase1name "EDGE_{{ i.ol_type }}"
     set proposal aes256gcm
     set dhgrp 20 21 14
-    set addke1 36 0
+    {{ 'set addke1 36 0' if options.pqc else 'unset addke1' }}
     set keepalive enable
     set keylifeseconds 3600
   next


### PR DESCRIPTION
Also, the command "set addke1 36 0" is not working any more, refer to version 7.6.7 (we need to change docs):

FortiGate-50G-5G (VPN-CASA-FULL) # set addke1 
none           NONE.
ml-kem-512     ML-KEM-512.
ml-kem-768     ML-KEM-768.
ml-kem-1024    ML-KEM-1024.
kyber512       KYBER512.
kyber768       KYBER768.
kyber1024      KYBER1024.
frodo-l1       FRODO L1.
frodo-l3       FRODO L3.
frodo-l5       FRODO L5.
bike-l1        BIKE L1.
bike-l3        BIKE L3.
bike-l5        BIKE L5.
hqc128         HQC128.
hqc192         HQC192.
hqc256         HQC256.

Thanks,

dsammartano@fortinet.com